### PR TITLE
DO NOT MERGE: remove keyhash from name

### DIFF
--- a/fio.contracts/contracts/fio.address/fio.address.abi
+++ b/fio.contracts/contracts/fio.address/fio.address.abi
@@ -66,10 +66,7 @@
         },{
           "name": "clientkey",
           "type": "string"
-        },{
-            "name": "keyhash",
-            "type": "uint128"
-          }
+        }
       ]
      },{
       "name": "regaddress",

--- a/fio.contracts/contracts/fio.address/fio.address.cpp
+++ b/fio.contracts/contracts/fio.address/fio.address.cpp
@@ -93,7 +93,6 @@ namespace fioio {
                     accountmap.emplace(_self, [&](struct eosio_name &p) {
                         p.account = nmi;
                         p.clientkey = owner_fio_public_key;
-                        p.keyhash = string_to_uint128_hash(owner_fio_public_key.c_str());
                     });
                 } else {
                     fio_400_assert(accountExists, "owner_account", owner_account,
@@ -1022,7 +1021,6 @@ namespace fioio {
                 accountmap.emplace(_self, [&](struct eosio_name &p) {
                     p.account = account.value;
                     p.clientkey = client_key;
-                    p.keyhash = string_to_uint128_hash(client_key.c_str());
                 });
             }
         }

--- a/fio.contracts/contracts/fio.address/fio.address.hpp
+++ b/fio.contracts/contracts/fio.address/fio.address.hpp
@@ -88,17 +88,10 @@ namespace fioio {
 
         uint64_t account = 0;
         string clientkey = nullptr;
-        uint128_t keyhash = 0;
-
         uint64_t primary_key() const { return account; }
-        uint128_t by_keyhash() const { return keyhash; }
 
-        EOSLIB_SERIALIZE(eosio_name, (account)(clientkey)(keyhash)
-        )
+        EOSLIB_SERIALIZE(eosio_name, (account)(clientkey))
     };
 
-    typedef multi_index<"accountmap"_n, eosio_name,
-            indexed_by<"bykey"_n, const_mem_fun < eosio_name, uint128_t, &eosio_name::by_keyhash>>
-    >
-    eosio_names_table;
+    typedef multi_index<"accountmap"_n, eosio_name> eosio_names_table;
 }


### PR DESCRIPTION
Discovered by BlockTrades that a table member was not being used by a contract.
Performed the cleanup and found that this member is actually being used for table lookups via get_fio_names api endpoint. Removing this key would require get_fio_names lookup updates to use different key. 