### PR TITLE
ERIC TO MERGE -- only collect fees on propose when a fio system account is proposing 

### DIFF
--- a/fio.contracts/contracts/eosio.msig/src/eosio.msig.cpp
+++ b/fio.contracts/contracts/eosio.msig/src/eosio.msig.cpp
@@ -61,12 +61,28 @@ namespace eosio {
         uint64_t sizep = transaction_size();
 
 
-        //collect fees.
-        eosio::action{
-                permission_level{_proposer, "active"_n},
-                fioio::FeeContract, "bytemandfee"_n,
-                std::make_tuple(std::string("msig_propose"), _proposer, _maxfee,sizep)
-        }.send();
+        //collect fee if its not a fio system account.
+        if(!(   _proposer == fioio::MSIGACCOUNT ||
+                _proposer == fioio::WRAPACCOUNT ||
+                _proposer == fioio::SYSTEMACCOUNT ||
+                _proposer == fioio::ASSERTACCOUNT ||
+                _proposer == fioio::REQOBTACCOUNT ||
+                _proposer == fioio::FeeContract ||
+                _proposer == fioio::AddressContract ||
+                _proposer == fioio::TPIDContract ||
+                _proposer == fioio::TokenContract ||
+                _proposer == fioio::FOUNDATIONACCOUNT ||
+                _proposer == fioio::TREASURYACCOUNT ||
+                _proposer == fioio::FIOSYSTEMACCOUNT ||
+                _proposer == fioio::FIOACCOUNT)
+                ) {
+            //collect fees.
+            eosio::action{
+                    permission_level{_proposer, "active"_n},
+                    fioio::FeeContract, "bytemandfee"_n,
+                    std::make_tuple(std::string("msig_propose"), _proposer, _maxfee, sizep)
+            }.send();
+        }
 
         auto packed_requested = pack(_requested);
         auto res = ::check_transaction_authorization(trx_pos, size,

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -61,14 +61,9 @@ namespace eosio {
                       EOS_ASSERT(act->account.to_string() == fioio::map_to_contract(act->name.to_string()), action_validate_exception,
                                  "Unknown action ${action} in contract ${contract}",
                                  ("action", act->name)("contract", act->account));
-
-                      //check for propose or updateauth              
-                      if ((act->name != name("propose")) && (act->name != name("updateauth")) ) {
-                          EOS_ASSERT(sizeof(act->data) < config::max_transaction_size, action_validate_exception,
-                                     " action ${action} in contract ${contract} too large",
-                                     ("action", act->name)("contract", act->account));
-                      }
-
+                      EOS_ASSERT(sizeof(act->data) < config::max_transaction_size, action_validate_exception,
+                                 " action ${action} in contract ${contract} too large",
+                                 ("action", act->name)("contract", act->account));
                     }
                     else {
                       EOS_ASSERT(sizeof(act->data) <  config::max_nonce_size, action_validate_exception,


### PR DESCRIPTION
only collect fees on propose when its a fio system account proposing the msig.

this brings propose into the same policy which is used for updateauth. 
it permits the system accounts to propose large msigs necessary for the system contract mods.