### PR TITLE
ERIC TO MERGE -- disable fees on propose if proposer is a fio system account or a top21 BP.

### DIFF
--- a/fio.contracts/contracts/eosio.msig/CMakeLists.txt
+++ b/fio.contracts/contracts/eosio.msig/CMakeLists.txt
@@ -3,6 +3,7 @@ add_contract(eosio.msig eosio.msig ${CMAKE_CURRENT_SOURCE_DIR}/src/eosio.msig.cp
 target_include_directories(eosio.msig
         PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../fio.system/include
         ${CMAKE_CURRENT_SOURCE_DIR}/../
         )
 

--- a/fio.contracts/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
+++ b/fio.contracts/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
@@ -3,6 +3,7 @@
 #include <eosiolib/eosio.hpp>
 #include <eosiolib/ignore.hpp>
 #include <eosiolib/transaction.hpp>
+#include <fio.common/fio.common.hpp>
 
 
 namespace eosio {
@@ -11,7 +12,12 @@ namespace eosio {
     static const uint64_t APPROVERAM = 1024; //integrated
 
     class [[eosio::contract("eosio.msig")]] multisig : public contract {
+    private:
+        eosiosystem::top_producers_table topprods;
     public:
+        multisig(name s, name code, datastream<const char *> ds) : contract(s, code, ds),
+        topprods(SYSTEMACCOUNT, SYSTEMACCOUNT.value) {
+        }
         using contract::contract;
 
         [[eosio::action]]

--- a/fio.contracts/contracts/eosio.msig/src/eosio.msig.cpp
+++ b/fio.contracts/contracts/eosio.msig/src/eosio.msig.cpp
@@ -23,6 +23,10 @@ namespace eosio {
         return ct;
     }
 
+
+
+
+
     /**********
      * This action permits the invoker to propose a multi signature operation. The operaton must be
      * signed by the list of requested accounts, once the accounts sign the approval then the tx
@@ -38,6 +42,9 @@ namespace eosio {
                            ignore<uint64_t> max_fee,
                            ignore<transaction> trx
                            ) {
+
+
+
         name _proposer;
         name _proposal_name;
         std::vector <permission_level> _requested;
@@ -60,6 +67,12 @@ namespace eosio {
         //get the sizes of tx.
         uint64_t sizep = transaction_size();
 
+        bool isTopProd = false;
+        auto tpiter = topprods.find(_proposer.value);
+        if (tpiter != topprods.end()){
+            isTopProd = true;
+        }
+
 
         //collect fee if its not a fio system account.
         if(!(   _proposer == fioio::MSIGACCOUNT ||
@@ -74,7 +87,8 @@ namespace eosio {
                 _proposer == fioio::FOUNDATIONACCOUNT ||
                 _proposer == fioio::TREASURYACCOUNT ||
                 _proposer == fioio::FIOSYSTEMACCOUNT ||
-                _proposer == fioio::FIOACCOUNT)
+                _proposer == fioio::FIOACCOUNT ||
+                isTopProd)
                 ) {
             //collect fees.
             eosio::action{


### PR DESCRIPTION
this pr permits BPs and fio system accounts to run msig propose without paying fees.

this permits BPs and fio system accounts to propose any size of proposal they wish.
this provides non BPs and non system accounts pay the fees, and have the 8098 byte limit on Total tx size.

this was tested by running the MSIG SOAPUI tests.
this was tested by submitting a large proposal using a non system account and non BP account, this gets the error transaction too large.
this was tested by submitting a large proposal using a system account (eosio), after modifying its auths to become msig, this succeeds.
this was tested by submitting a large proposal using one of the BP accounts (hfdg2qumuvlc), after modifying it to become msig, this succeeds.