### PR TITLE
update bpclaim time to be seconds per day plus 1

### DIFF
--- a/fio.contracts/contracts/fio.treasury/fio.treasury.cpp
+++ b/fio.contracts/contracts/fio.treasury/fio.treasury.cpp
@@ -11,7 +11,7 @@
 #define BPMAXTOMINT     50000000000000          // 50,000  FIO
 #define FDTNMAXRESERVE  181253654000000000      // 181,253,654 FIO
 #define BPMAXRESERVE    10000000000000000       // 10,000,000 FIO
-#define PAYSCHEDTIME    172801                  // 1 day  ( block time )
+#define PAYSCHEDTIME    86401                   //seconds per day + 1
 #define PAYABLETPIDS    100
 
 #include "fio.treasury.hpp"


### PR DESCRIPTION
value was based on block time, but code logic does the check based on seconds. resolve this by changing the constant to be seconds based