### PR TITLE
Update error messaging in voting.cpp

### DIFF
--- a/fio.contracts/contracts/fio.system/src/voting.cpp
+++ b/fio.contracts/contracts/fio.system/src/voting.cpp
@@ -196,7 +196,8 @@ namespace eosiosystem {
 
         auto namesbyname = _fionames.get_index<"byname"_n>();
         auto fioname_iter = namesbyname.find(nameHash);
-        fio_404_assert(fioname_iter != namesbyname.end(), "FIO Address not found", ErrorFioNameNotRegistered);
+        fio_400_assert(fioname_iter != namesbyname.end(), "fio_address", fio_address,
+                       "FIO Address not registered", ErrorFioNameNotReg);
 
         //check that the name is not expired
         uint32_t name_expiration = fioname_iter->expiration;
@@ -210,7 +211,8 @@ namespace eosiosystem {
         auto domainsbyname = _domains.get_index<"byname"_n>();
         auto domains_iter = domainsbyname.find(domainHash);
 
-        fio_404_assert(domains_iter != domainsbyname.end(), "FIO Domain not found", ErrorDomainNotFound);
+        fio_400_assert(domains_iter != domainsbyname.end(), "fio_address", fio_address,
+                       "FIO Address not registered", ErrorFioNameNotReg);
 
         uint32_t expiration = domains_iter->expiration;
 
@@ -282,7 +284,8 @@ namespace eosiosystem {
         auto namesbyname = _fionames.get_index<"byname"_n>();
         auto fioname_iter = namesbyname.find(nameHash);
 
-        fio_404_assert(fioname_iter != namesbyname.end(), "FIO Address not found", ErrorFioNameNotRegistered);
+        fio_400_assert(fioname_iter != namesbyname.end(), "fio_address", fio_address,
+                       "FIO Address not registered", ErrorFioNameNotReg);
 
         //check that the name is not expired
         uint32_t name_expiration = fioname_iter->expiration;
@@ -296,7 +299,8 @@ namespace eosiosystem {
         auto domainsbyname = _domains.get_index<"byname"_n>();
         auto domains_iter = domainsbyname.find(domainHash);
 
-        fio_404_assert(domains_iter != domainsbyname.end(), "FIO Domain not found", ErrorDomainNotFound);
+        fio_400_assert(domains_iter != domainsbyname.end(), "fio_address", fio_address,
+                       "FIO Address not registered", ErrorFioNameNotReg);
 
         uint32_t expiration = domains_iter->expiration;
         fio_400_assert(present_time <= expiration, "domain", fa.fiodomain, "FIO Domain expired",
@@ -496,7 +500,7 @@ namespace eosiosystem {
 
         FioAddress fa;
         getFioAddressStruct(fio_address, fa);
-        fio_400_assert(validateFioNameFormat(fa), "fio_address", fio_address, "FIO Address not found",
+        fio_400_assert(validateFioNameFormat(fa), "fio_address", fio_address, "Invalid FIO Address format",
                        ErrorDomainAlreadyRegistered);
 
         uint128_t voterHash = string_to_uint128_hash(fio_address.c_str());
@@ -518,7 +522,8 @@ namespace eosiosystem {
         auto domainsbyname = _domains.get_index<"byname"_n>();
         auto voterdomain_iter = domainsbyname.find(voterDomainHash);
 
-        fio_404_assert(voterdomain_iter != domainsbyname.end(), "FIO Address not found", ErrorDomainNotFound);
+        fio_400_assert(voterdomain_iter != domainsbyname.end(), "fio_address", fio_address,
+                       "FIO Address not registered", ErrorFioNameNotReg);
         fio_403_assert(voter_iter->owner_account == actor.value, ErrorSignature);
 
         uint32_t voterdomain_expiration = voterdomain_iter->expiration;
@@ -532,7 +537,8 @@ namespace eosiosystem {
             uint128_t domainHash = string_to_uint128_hash(fa.fiodomain.c_str());
 
             auto fioname_iter = namesbyname.find(nameHash);
-            fio_404_assert(fioname_iter != namesbyname.end(), "FIO Address not found", ErrorFioNameNotRegistered);
+            fio_400_assert(fioname_iter != namesbyname.end(), "fio_address", fio_address,
+                           "FIO Address not registered", ErrorFioNameNotReg);
 
             uint32_t name_expiration = fioname_iter->expiration;
 
@@ -542,7 +548,8 @@ namespace eosiosystem {
 
             auto domains_iter = domainsbyname.find(domainHash);
 
-            fio_404_assert(domains_iter != domainsbyname.end(), "FIO Domain not found", ErrorDomainNotFound);
+            fio_400_assert(domains_iter != domainsbyname.end(), "fio_address", fio_address,
+                           "FIO Address not registered", ErrorFioNameNotReg);
 
             uint32_t expiration = domains_iter->expiration;
             fio_400_assert(present_time <= expiration, "domain", fa.fiodomain, "FIO Domain expired",
@@ -620,7 +627,9 @@ namespace eosiosystem {
         getFioAddressStruct(proxy, fa);
         getFioAddressStruct(fio_address, va);
 
-        fio_400_assert(validateFioNameFormat(fa), "fio_address", fio_address, "FIO Address not found",
+        fio_400_assert(validateFioNameFormat(va), "proxy", proxy, "Invalid FIO Address format",
+                       ErrorDomainAlreadyRegistered);
+        fio_400_assert(validateFioNameFormat(fa), "fio_address", fio_address, "Invalid FIO Address format",
                        ErrorDomainAlreadyRegistered);
 
         uint128_t voterHash = string_to_uint128_hash(fio_address.c_str());
@@ -641,8 +650,8 @@ namespace eosiosystem {
 
         auto domainsbyname = _domains.get_index<"byname"_n>();
         auto voterdomain_iter = domainsbyname.find(voterDomainHash);
-
-        fio_404_assert(voterdomain_iter != domainsbyname.end(), "FIO Address not found", ErrorDomainNotFound);
+        fio_400_assert(voterdomain_iter != domainsbyname.end(), "fio_address", fio_address,
+                       "FIO Address not registered", ErrorFioNameNotReg);
         fio_403_assert(voter_iter->owner_account == actor.value, ErrorSignature);
 
         uint32_t voterdomain_expiration = voterdomain_iter->expiration;
@@ -652,25 +661,26 @@ namespace eosiosystem {
         uint128_t nameHash = string_to_uint128_hash(fa.fioaddress.c_str());
         uint128_t domainHash = string_to_uint128_hash(fa.fiodomain.c_str());
         auto fioname_iter = namesbyname.find(nameHash);
-        fio_404_assert(fioname_iter != namesbyname.end(), "FIO Address not found", ErrorFioNameNotRegistered);
+        fio_400_assert(fioname_iter != namesbyname.end(), "proxy", proxy,
+                       "FIO Address not registered", ErrorFioNameNotReg);
 
         //check that the name is not expired
         uint32_t name_expiration = fioname_iter->expiration;
-
         uint64_t account = fioname_iter->owner_account;
-        fio_400_assert(present_time <= name_expiration, "fio_address", proxy,
+        fio_400_assert(present_time <= name_expiration, "proxy", proxy,
                        "FIO Address expired", ErrorFioNameExpired);
 
         auto domains_iter = domainsbyname.find(domainHash);
 
-        fio_404_assert(domains_iter != domainsbyname.end(), "FIO Domain not found", ErrorDomainNotFound);
+        fio_400_assert(domains_iter != domainsbyname.end(), "proxy", proxy,
+                       "FIO Address not registered", ErrorFioNameNotReg);
 
         uint32_t expiration = domains_iter->expiration;
 
         //add 30 days to the domain expiration, this call will work until 30 days past expire.
         expiration = get_time_plus_seconds(expiration,SECONDS30DAYS);
 
-        fio_400_assert(present_time <= expiration, "domain", fa.fiodomain, "FIO Domain expired",
+        fio_400_assert(present_time <= expiration, "proxy", proxy, "FIO Domain expired",
                        ErrorDomainExpired);
 
         auto proxy_name = name{account};
@@ -1030,7 +1040,8 @@ namespace eosiosystem {
         auto domainsbyname = _domains.get_index<"byname"_n>();
         auto domains_iter = domainsbyname.find(domainHash);
 
-        fio_404_assert(domains_iter != domainsbyname.end(), "FIO Domain not found", ErrorDomainNotFound);
+        fio_400_assert(domains_iter != domainsbyname.end(), "fio_address", fio_address,
+                       "FIO Address not registered", ErrorFioNameNotReg);
 
         uint32_t expiration = domains_iter->expiration;
         fio_400_assert(present_time <= expiration, "domain", fa.fiodomain, "FIO Domain expired",
@@ -1103,7 +1114,8 @@ namespace eosiosystem {
         auto domainsbyname = _domains.get_index<"byname"_n>();
         auto domains_iter = domainsbyname.find(domainHash);
 
-        fio_404_assert(domains_iter != domainsbyname.end(), "FIO Domain not found", ErrorDomainNotFound);
+        fio_400_assert(domains_iter != domainsbyname.end(), "fio_address", fio_address,
+                       "FIO Address not registered", ErrorFioNameNotReg);
 
         uint32_t expiration = domains_iter->expiration;
 


### PR DESCRIPTION
Multiple action calls did not match v1.0 API spec. 404->400 error response changes along with added proxy validation on voteproxy. 