### PR TITLE
modify BPclaim to have vote shares sorted by votes, mod logic to check if chain is activated.

### DIFF
--- a/fio.contracts/contracts/fio.system/src/producer_pay.cpp
+++ b/fio.contracts/contracts/fio.system/src/producer_pay.cpp
@@ -29,7 +29,7 @@ namespace eosiosystem {
         _gstate2.last_block_num = timestamp;
 
         /** until voting activated fio crosses this threshold no new rewards are paid */
-        if( _gstate.total_voted_fio < MINVOTEDFIO ){
+        if( _gstate.total_voted_fio < MINVOTEDFIO && _gstate.thresh_voted_fio_time == time_point() ){
             return;
         }
 

--- a/fio.contracts/contracts/fio.treasury/fio.treasury.cpp
+++ b/fio.contracts/contracts/fio.treasury/fio.treasury.cpp
@@ -114,7 +114,7 @@ public:
                 require_auth(actor);
 
                 gstate = global.get();
-                check( gstate.total_voted_fio >= MINVOTEDFIO,
+                check( gstate.total_voted_fio >= MINVOTEDFIO || gstate.thresh_voted_fio_time != time_point() ,
                        "cannot claim rewards until the chain voting threshold is exceeded" );
 
                 auto namesbyname = fionames.get_index<"byname"_n>();
@@ -177,7 +177,7 @@ public:
                                                 });
                                 }
                                 bpcounter++;
-                                if (bpcounter > MAXBPS) break;
+                                if (bpcounter >= MAXBPS) break;
                         } // &itr : producers table
 
                         //Move 1/365 of the bucketpool to the bpshare
@@ -235,25 +235,25 @@ public:
                         uint64_t bpcount = std::distance(voteshares.begin(), voteshares.end());
                         uint64_t abpcount = MAXACTIVEBPS;
 
-                        if (bpcount > MAXBPS) bpcount = MAXBPS; //limit to 42 producers in voteshares
                         if (bpcount <= MAXACTIVEBPS) abpcount = bpcount;
                         auto bprewardstat = bprewards.get();
                         uint64_t tostandbybps = static_cast<uint64_t>(bprewardstat.rewards * .60);
                         uint64_t toactivebps = static_cast<uint64_t>(bprewardstat.rewards * .40);
 
                         bpcounter = 0;
-                        for (const auto &itr : voteshares) {
-                                if (bpcounter <= abpcount) {
-                                        voteshares.modify(itr, get_self(), [&](auto &entry) {
-                                                        entry.abpayshare = static_cast<uint64_t>(toactivebps / abpcount);;
-                                                });
-                                }
+                        auto votesharesiter = voteshares.get_index<"byvotes"_n>();
+                        for (const auto &itr : votesharesiter) {
+                            if (bpcounter > (bpcount - abpcount)-1) {
+                                voteshares.modify(itr, get_self(), [&](auto &entry) {
+                                    entry.abpayshare = static_cast<uint64_t>(toactivebps / abpcount);;
+                                });
+                            }
                                 voteshares.modify(itr, get_self(), [&](auto &entry) {
                                                 entry.sbpayshare =  static_cast<uint64_t>((tostandbybps) * (itr.votes / gstate.total_producer_vote_weight));;
                                         });
                                 bpcounter++;
                         } // &itr : voteshares
-                        
+
                         //Start 24 track for daily pay schedule
                         if (state.payschedtimer == 0){
                                 state.payschedtimer = now();

--- a/fio.contracts/contracts/fio.treasury/fio.treasury.hpp
+++ b/fio.contracts/contracts/fio.treasury/fio.treasury.hpp
@@ -45,10 +45,12 @@ namespace fioio {
         double votes;
 
         uint64_t primary_key() const { return owner.value; }
+        double by_votes() const { return votes; }
 
         EOSLIB_SERIALIZE( bppaysched, (owner)(abpayshare)(sbpayshare)(votes)
         )
     };
 
-    typedef eosio::multi_index<"voteshares"_n, bppaysched> voteshares_table;
+    typedef eosio::multi_index<"voteshares"_n, bppaysched,
+            indexed_by<"byvotes"_n, const_mem_fun < bppaysched, double, &bppaysched::by_votes> >> voteshares_table;
 }


### PR DESCRIPTION
Hotfix from PR #63 

> this PR modifies the logic used to check that the chain has been activated, we add a check to the thresh_voted_fio_time so as to ensure that if the chain has been activated, we will not lose activation if votes are lost...