### PR TITLE
fix doubling of voting weight when a proxy is voted for, fix BP claim  when over 42 active BPs are present.

### DIFF
--- a/fio.contracts/contracts/fio.system/src/voting.cpp
+++ b/fio.contracts/contracts/fio.system/src/voting.cpp
@@ -863,7 +863,7 @@ namespace eosiosystem {
             new_vote_weight += voter->proxied_vote_weight;
         }
 
-        if( !(voter->proxy) ) {
+        if( !(proxy) ) {
 
             if( voter->last_vote_weight > 0.0 ) {
                 _gstate.total_voted_fio -= voter->last_vote_weight;


### PR DESCRIPTION
this PR merges the hot fixes placed into the master branch..

this PR fixes the doubling of voting weight when a user sets a proxy for voting.
this PR fixes the providing of the correct BPs into the vote shares when there are more than 42 BPs active.

these changes have NOT been tested in this form. it is recommended that we set up a server with these changes and the shortened claim period for pawel to test after these changes are merged into develop.

