### PR TITLE
fix logic error, increment bpcount when we place into table

### DIFF
--- a/fio.contracts/contracts/fio.treasury/fio.treasury.cpp
+++ b/fio.contracts/contracts/fio.treasury/fio.treasury.cpp
@@ -183,8 +183,9 @@ public:
                                                         p.owner = itr->owner;
                                                         p.votes = itr->total_votes;
                                                 });
+                                        bpcounter++;
                                 }
-                                bpcounter++;
+
                                 if (bpcounter >= MAXBPS) break;
                         } // &itr : producers table
 


### PR DESCRIPTION
this PR ensures the vote shares is filled with the correct number of BPs 

this needs tested on testnet.