### PR TITLE
traverse the prototalvote index from the begin instead of end

### DIFF
--- a/fio.contracts/contracts/fio.treasury/fio.treasury.cpp
+++ b/fio.contracts/contracts/fio.treasury/fio.treasury.cpp
@@ -170,13 +170,12 @@ public:
                     int64_t bpcounter = 0;
                     uint64_t activecount = 0;
                     auto proditer = producers.get_index<"prototalvote"_n>();
-                    auto itr = proditer.end();
+                    auto itr = proditer.begin();
 
                     int32_t prodcount = std::distance(producers.begin(), producers.end());
                     check(prodcount > 0,"error -- no producers");
 
-                    for (int32_t idx=prodcount-1;idx >=0; idx--) {
-                        --itr;
+                    for (int32_t idx=0;idx < prodcount; idx++) {
                         if (itr->is_active) {
                             voteshares.emplace(actor, [&](auto &p) {
                                 p.owner = itr->owner;
@@ -185,6 +184,7 @@ public:
                         }
                         bpcounter++;
                         if (bpcounter >= MAXBPS) break;
+                        itr++;
                     } // &itr : producers table
 
                     //Move 1/365 of the bucketpool to the bpshare

--- a/fio.contracts/contracts/fio.treasury/fio.treasury.cpp
+++ b/fio.contracts/contracts/fio.treasury/fio.treasury.cpp
@@ -169,6 +169,8 @@ public:
                     //Create the payment schedule
                     int64_t bpcounter = 0;
                     uint64_t activecount = 0;
+                    //prototal votes returns active producers sorted beginning at the highest voted to the lowest voted
+                    // active producers  then for inactive producers lowest voted to highest voted.
                     auto proditer = producers.get_index<"prototalvote"_n>();
                     auto itr = proditer.begin();
 
@@ -181,10 +183,11 @@ public:
                                 p.owner = itr->owner;
                                 p.votes = itr->total_votes;
                             });
+                            bpcounter++;
                         }
-                        bpcounter++;
-                        if (bpcounter >= MAXBPS) break;
+
                         itr++;
+                        if (bpcounter >= MAXBPS) break;
                     } // &itr : producers table
 
                     //Move 1/365 of the bucketpool to the bpshare


### PR DESCRIPTION
prototalvote orders bps in the following way, active BPs in order of highest votes to least, then not active BPs from lowest votes to highest....