### PR TITLE
MAS-1653 - Fix type for domain expiration

### DIFF
--- a/fio.contracts/contracts/fio.address/fio.address.abi
+++ b/fio.contracts/contracts/fio.address/fio.address.abi
@@ -54,7 +54,7 @@
          "type": "uint8"
        },{
           "name": "expiration",
-          "type": "uint32"
+          "type": "uint64"
         }
       ]
     },{


### PR DESCRIPTION
- Altered domains table type for expiration field to uint64 type
- Testing: Spun up local test chain with old abi, set contract to new abi and was able to continue registering new fio domains to the table