### PR TITLE
remove transaction size check from fio.token transfer action

### DIFF
--- a/fio.contracts/contracts/fio.token/src/fio.token.cpp
+++ b/fio.contracts/contracts/fio.token/src/fio.token.cpp
@@ -171,7 +171,7 @@ namespace eosio {
 
         /* we permit the use of transfer from the system account to any other accounts,
          * we permit the use of transfer from the treasury account to any other accounts.
-         * we permit the use of transfer from any other accounts to the treasury account.
+         * we permit the use of transfer from any other accounts to the treasury account for fees.
          */
         if (from != SYSTEMACCOUNT && from != TREASURYACCOUNT) {
             check(to == TREASURYACCOUNT, "transfer not allowed");
@@ -202,10 +202,6 @@ namespace eosio {
 
         sub_balance(from, quantity);
         add_balance(to, quantity, payer);
-
-        fio_400_assert(transaction_size() <= MAX_TRX_SIZE, "transaction_size", std::to_string(transaction_size()),
-          "Transaction is too large", ErrorTransactionTooLarge);
-
     }
 
 


### PR DESCRIPTION
this PR removes the check on transaction size for the transfer action in the fio.token contract.
code analysis shows that the action already requires system and treasury authority, which requires MSIG of 2/3 plus 1 from producers.
all calls to transfer within the contracts have other max tx size checks or they require auth of an MSIG system account.

TESTING NOTE -- this change will break the MSIG SOAPUI tests, the max size tests (which assume a failure when large tx are sent through propose and updateauth)...these will now succeed and be charged the appropriate byte wise fee.