### PR TITLE
update ram bump on byte wise fee calls, do size wise ram bump

### DIFF
--- a/fio.contracts/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
+++ b/fio.contracts/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
@@ -8,8 +8,8 @@
 
 namespace eosio {
 
-    static const uint64_t PROPOSERAM = 2560; //integrated.
-    static const uint64_t APPROVERAM = 1024; //integrated
+    static const uint64_t PROPOSERAM = 1024;
+    static const uint64_t APPROVERAM = 1024;
 
     class [[eosio::contract("eosio.msig")]] multisig : public contract {
     private:

--- a/fio.contracts/contracts/eosio.msig/src/eosio.msig.cpp
+++ b/fio.contracts/contracts/eosio.msig/src/eosio.msig.cpp
@@ -123,11 +123,20 @@ namespace eosio {
         });
 
         if (PROPOSERAM > 0) {
+            //get the tx size and divide by 1000
+            int64_t bytesize = transaction_size();
+            int64_t remv = bytesize % 1000;
+            int64_t divv = bytesize / 1000;
+            if (remv > 0 ){
+                divv ++;
+            }
+            uint64_t rambump = divv * PROPOSERAM;
+            //multiply by the PROPOSERAM
             action(
                     permission_level{SYSTEMACCOUNT, "active"_n},
                     "eosio"_n,
                     "incram"_n,
-                    std::make_tuple(_proposer, PROPOSERAM)
+                    std::make_tuple(_proposer, rambump)
             ).send();
         }
 

--- a/fio.contracts/contracts/fio.system/include/fio.system/native.hpp
+++ b/fio.contracts/contracts/fio.system/include/fio.system/native.hpp
@@ -84,12 +84,12 @@ namespace eosiosystem {
         )
     };
 
-    static const uint64_t LINKAUTHRAM = 1024; //integrated.
-    static const uint64_t REGPRODUCERRAM = 1024; //integrated.
-    static const uint64_t REGPROXYRAM = 1024;//integrated.
-    static const uint64_t VOTEPROXYRAM = 512; //integrated.
-    static const uint64_t VOTEPRODUCERRAM = 1024; //integrated.
-    static const uint64_t UPDATEAUTHRAM = 1024; //integrated.
+    static const uint64_t LINKAUTHRAM = 1024;
+    static const uint64_t REGPRODUCERRAM = 1024;
+    static const uint64_t REGPROXYRAM = 1024;
+    static const uint64_t VOTEPROXYRAM = 512;
+    static const uint64_t VOTEPRODUCERRAM = 1024;
+    static const uint64_t UPDATEAUTHRAM = 1024;
 
     /*
      * Method parameters commented out to prevent generation of code that parses input data.
@@ -162,11 +162,19 @@ namespace eosiosystem {
                            "Waits not supported", ErrorNoAuthWaits);
 
             if (UPDATEAUTHRAM > 0) {
+                //get the tx size and divide by 1000
+                int64_t bytesize = transaction_size();
+                int64_t remv = bytesize % 1000;
+                int64_t divv = bytesize / 1000;
+                if (remv > 0 ){
+                    divv ++;
+                }
+                uint64_t rambump = divv * UPDATEAUTHRAM;
                 action(
                         permission_level{SYSTEMACCOUNT, "active"_n},
                         "eosio"_n,
                         "incram"_n,
-                        std::make_tuple(account, UPDATEAUTHRAM)
+                        std::make_tuple(account, rambump)
                 ).send();
             }
 


### PR DESCRIPTION
this PR modifies the RAM bump on eosio.msig propose and fio.system updateauth, the RAM bump is now computed as the number of bytes in the TX divided by 1000 rounded up, and then multiplied by 1024.

this was tested by running multis tests and seeing that update auth and propose work successfully, more testing is needed to prove the RAM bump is accurate...this will be completed in UAT testing.