### PR TITLE
Update contract action parameters to use const &

### DIFF
--- a/fio.contracts/contracts/fio.system/include/fio.system/fio.system.hpp
+++ b/fio.contracts/contracts/fio.system/include/fio.system/fio.system.hpp
@@ -293,12 +293,12 @@ public:
 
     // Actions:
     [[eosio::action]]
-    void init(unsigned_int version, symbol core);
+    void init(const unsigned_int  &version, const symbol &core);
 
     //this action inits the locked token holder table.
     [[eosio::action]]
-    void addlocked(const name &owner, const int64_t amount,
-                    const int16_t locktype);
+    void addlocked(const name &owner, const int64_t &amount,
+                    const int16_t &locktype);
 
     [[eosio::action]]
     void onblock(ignore <block_header> header);
@@ -370,13 +370,13 @@ public:
     void updlbpclaim(const name &producer);
 
     [[eosio::action]]
-    void setpriv(name account, uint8_t is_priv);
+    void setpriv(const name &account,const uint8_t &is_priv);
 
     [[eosio::action]]
-    void rmvproducer(name producer);
+    void rmvproducer(const name &producer);
 
     [[eosio::action]]
-    void updtrevision(uint8_t revision);
+    void updtrevision(const uint8_t &revision);
 
     using init_action = eosio::action_wrapper<"init"_n, &system_contract::init>;
     using regproducer_action = eosio::action_wrapper<"regproducer"_n, &system_contract::regproducer>;

--- a/fio.contracts/contracts/fio.system/include/fio.system/native.hpp
+++ b/fio.contracts/contracts/fio.system/include/fio.system/native.hpp
@@ -113,18 +113,18 @@ namespace eosiosystem {
          *     an amount equal to the current new account creation fee.
          */
         [[eosio::action]]
-        void newaccount(name creator,
-                        name name,
-                        ignore <authority> owner,
-                        ignore <authority> active);
+        void newaccount(const name &creator,
+                        const name &name,
+                         ignore <authority> owner,
+                         ignore <authority> active);
 
 
         [[eosio::action]]
-        void updateauth(name account,
-                        name permission,
-                        name parent,
-                        authority auth,
-                        const uint64_t max_fee) {
+        void updateauth(const name &account,
+                        const name &permission,
+                        const name &parent,
+                        const authority &auth,
+                        const uint64_t &max_fee) {
             require_auth(account);
 
             //check the list of system accounts, if it is one of these do not charge the fees.
@@ -181,9 +181,9 @@ namespace eosiosystem {
         }
 
         [[eosio::action]]
-        void deleteauth(name account,
-                        name permission,
-                        const uint64_t max_fee) {
+        void deleteauth(const name &account,
+                        const name &permission,
+                        const uint64_t &max_fee) {
             require_auth(account);
 
             eosio::action{
@@ -197,11 +197,11 @@ namespace eosiosystem {
         }
 
         [[eosio::action]]
-        void linkauth(name account,
-                      name code,
-                      name type,
-                      name requirement,
-                      uint64_t max_fee) {
+        void linkauth(const name &account,
+                      const name &code,
+                      const name &type,
+                      const name &requirement,
+                      const uint64_t &max_fee) {
 
             require_auth(account);
 
@@ -243,10 +243,10 @@ namespace eosiosystem {
         }
 
         [[eosio::action]]
-        void setabi(name account, const std::vector<char> &abi);
+        void setabi(const name &account, const std::vector<char> &abi);
 
         [[eosio::action]]
-        void setcode(name account, uint8_t vmtype, uint8_t vmversion, const std::vector<char> &code);
+        void setcode(const name &account, const uint8_t &vmtype, const uint8_t &vmversion, const std::vector<char> &code);
         //special note, dont add code here, setcode will not run this code.
 
         using newaccount_action = eosio::action_wrapper<"newaccount"_n, &native::newaccount>;

--- a/fio.contracts/contracts/fio.system/src/fio.system.cpp
+++ b/fio.contracts/contracts/fio.system/src/fio.system.cpp
@@ -69,7 +69,7 @@ namespace eosiosystem {
         set_blockchain_parameters(params);
     }
 
-    void eosiosystem::system_contract::setpriv(name account, uint8_t ispriv) {
+    void eosiosystem::system_contract::setpriv(const name &account, const uint8_t &ispriv) {
         require_auth(_self);
         set_privileged(account.value, ispriv);
 
@@ -78,7 +78,7 @@ namespace eosiosystem {
 
     }
 
-    void eosiosystem::system_contract::rmvproducer(name producer) {
+    void eosiosystem::system_contract::rmvproducer(const name &producer) {
         require_auth(_self);
         auto prod = _producers.find(producer.value);
         check(prod != _producers.end(), "producer not found");
@@ -91,7 +91,7 @@ namespace eosiosystem {
 
     }
 
-    void eosiosystem::system_contract::updtrevision(uint8_t revision) {
+    void eosiosystem::system_contract::updtrevision(const uint8_t &revision) {
         require_auth(_self);
         check(_gstate2.revision < 255, "can not increment revision"); // prevent wrap around
         check(revision == _gstate2.revision + 1, "can only increment revision by one");
@@ -109,10 +109,10 @@ namespace eosiosystem {
      *  who can create accounts with the creator's name as a suffix.
      *
      */
-    void eosiosystem::native::newaccount(name creator,
-                                         name newact,
-                                         ignore <authority> owner,
-                                         ignore <authority> active) {
+    void eosiosystem::native::newaccount(const name &creator,
+                                         const name &newact,
+                                          ignore <authority> owner,
+                                          ignore <authority> active) {
 
 
         require_auth(creator);
@@ -153,7 +153,7 @@ namespace eosiosystem {
     }
 
 
-    void eosiosystem::native::setabi(name acnt, const std::vector<char> &abi) {
+    void eosiosystem::native::setabi(const name &acnt, const std::vector<char> &abi) {
 
         require_auth(acnt);
         check((acnt == SYSTEMACCOUNT ||
@@ -184,14 +184,14 @@ namespace eosiosystem {
         }
     }
 
-    void eosiosystem::system_contract::init(unsigned_int version, symbol core) {
+    void eosiosystem::system_contract::init(const unsigned_int &version, const symbol &core) {
         require_auth(_self);
         check(version.value == 0, "unsupported version for init action");
     }
 
     //use this action to initialize the locked token holders table for the FIO protocol.
-    void eosiosystem::system_contract::addlocked(const name &owner, const int64_t amount,
-            const int16_t locktype) {
+    void eosiosystem::system_contract::addlocked(const name &owner, const int64_t &amount,
+            const int16_t &locktype) {
         require_auth(_self);
 
         check(is_account(owner),"account must pre exist");


### PR DESCRIPTION
- Update several contract actions to reflect implementation of eosio.contracts 1.9
- Updates change several contract actions to use proper const and pass by reference in parameters