### PR TITLE
Sec/fio#104 - Part 1 - Exit transaction early when insufficient CPU

### DIFF
--- a/libraries/chain/include/eosio/chain/block_timestamp.hpp
+++ b/libraries/chain/include/eosio/chain/block_timestamp.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <eosio/chain/config.hpp>
 
 #include <stdint.h>
@@ -9,102 +8,91 @@
 #include <fc/optional.hpp>
 #include <fc/exception/exception.hpp>
 
-namespace eosio {
-    namespace chain {
+namespace eosio { namespace chain {
 
-        /**
-        * This class is used in the block headers to represent the block time
-        * It is a parameterised class that takes an Epoch in milliseconds and
-        * and an interval in milliseconds and computes the number of slots.
-        **/
-        template<uint16_t IntervalMs, uint64_t EpochMs>
-        class block_timestamp {
-        public:
-            explicit block_timestamp(uint32_t s = 0) : slot(s) {}
+   /**
+   * This class is used in the block headers to represent the block time
+   * It is a parameterised class that takes an Epoch in milliseconds and
+   * and an interval in milliseconds and computes the number of slots.
+   **/
+   template<uint16_t IntervalMs, uint64_t EpochMs>
+   class block_timestamp {
+      public:
+         explicit block_timestamp( uint32_t s=0 ) :slot(s){}
 
-            block_timestamp(const fc::time_point &t) {
-                set_time_point(t);
-            }
+         block_timestamp(const fc::time_point& t) {
+            set_time_point(t);
+         }
 
-            block_timestamp(const fc::time_point_sec &t) {
-                set_time_point(t);
-            }
+         block_timestamp(const fc::time_point_sec& t) {
+            set_time_point(t);
+         }
 
-            static block_timestamp maximum() { return block_timestamp(0xffff); }
+         static block_timestamp maximum() { return block_timestamp( 0xffff ); }
+         static block_timestamp min() { return block_timestamp(0); }
 
-            static block_timestamp min() { return block_timestamp(0); }
+         block_timestamp next() const {
+            EOS_ASSERT( std::numeric_limits<uint32_t>::max() - slot >= 1, fc::overflow_exception, "block timestamp overflow" );
+            auto result = block_timestamp(*this);
+            result.slot += 1;
+            return result;
+         }
 
-            block_timestamp next() const {
-                EOS_ASSERT(std::numeric_limits<uint32_t>::max() - slot >= 1, fc::overflow_exception,
-                           "block timestamp overflow");
-                auto result = block_timestamp(*this);
-                result.slot += 1;
-                return result;
-            }
+         fc::time_point to_time_point() const {
+            return (fc::time_point)(*this);
+         }
 
-            fc::time_point to_time_point() const {
-                return (fc::time_point) (*this);
-            }
+         operator fc::time_point() const {
+            int64_t msec = slot * (int64_t)IntervalMs;
+            msec += EpochMs;
+            return fc::time_point(fc::milliseconds(msec));
+         }
 
-            operator fc::time_point() const {
-                int64_t msec = slot * (int64_t) IntervalMs;
-                msec += EpochMs;
-                return fc::time_point(fc::milliseconds(msec));
-            }
+         void operator = (const fc::time_point& t ) {
+            set_time_point(t);
+         }
 
-            void operator=(const fc::time_point &t) {
-                set_time_point(t);
-            }
+         bool   operator > ( const block_timestamp& t )const   { return slot >  t.slot; }
+         bool   operator >=( const block_timestamp& t )const   { return slot >= t.slot; }
+         bool   operator < ( const block_timestamp& t )const   { return slot <  t.slot; }
+         bool   operator <=( const block_timestamp& t )const   { return slot <= t.slot; }
+         bool   operator ==( const block_timestamp& t )const   { return slot == t.slot; }
+         bool   operator !=( const block_timestamp& t )const   { return slot != t.slot; }
+         uint32_t slot;
 
-            bool operator>(const block_timestamp &t) const { return slot > t.slot; }
+      private:
+      void set_time_point(const fc::time_point& t) {
+         auto micro_since_epoch = t.time_since_epoch();
+         auto msec_since_epoch  = micro_since_epoch.count() / 1000;
+         slot = ( msec_since_epoch - EpochMs ) / IntervalMs;
+      }
 
-            bool operator>=(const block_timestamp &t) const { return slot >= t.slot; }
+      void set_time_point(const fc::time_point_sec& t) {
+         uint64_t  sec_since_epoch = t.sec_since_epoch();
+         slot = (sec_since_epoch * 1000 - EpochMs) / IntervalMs;
+      }
+   }; // block_timestamp
 
-            bool operator<(const block_timestamp &t) const { return slot < t.slot; }
+   typedef block_timestamp<config::block_interval_ms,config::block_timestamp_epoch> block_timestamp_type;
 
-            bool operator<=(const block_timestamp &t) const { return slot <= t.slot; }
-
-            bool operator==(const block_timestamp &t) const { return slot == t.slot; }
-
-            bool operator!=(const block_timestamp &t) const { return slot != t.slot; }
-
-            uint32_t slot;
-
-        private:
-            void set_time_point(const fc::time_point &t) {
-                auto micro_since_epoch = t.time_since_epoch();
-                auto msec_since_epoch = micro_since_epoch.count() / 1000;
-                slot = (msec_since_epoch - EpochMs) / IntervalMs;
-            }
-
-            void set_time_point(const fc::time_point_sec &t) {
-                uint64_t sec_since_epoch = t.sec_since_epoch();
-                slot = (sec_since_epoch * 1000 - EpochMs) / IntervalMs;
-            }
-        }; // block_timestamp
-
-        typedef block_timestamp<config::block_interval_ms, config::block_timestamp_epoch> block_timestamp_type;
-
-    }
-} /// eosio::chain
+} } /// eosio::chain
 
 
 #include <fc/reflect/reflect.hpp>
-
 FC_REFLECT(eosio::chain::block_timestamp_type, (slot))
 
 namespace fc {
-    template<uint16_t IntervalMs, uint64_t EpochMs>
-    void to_variant(const eosio::chain::block_timestamp<IntervalMs, EpochMs> &t, fc::variant &v) {
-        to_variant((fc::time_point) t, v);
-    }
+  template<uint16_t IntervalMs, uint64_t EpochMs>
+  void to_variant(const eosio::chain::block_timestamp<IntervalMs,EpochMs>& t, fc::variant& v) {
+     to_variant( (fc::time_point)t, v);
+  }
 
-    template<uint16_t IntervalMs, uint64_t EpochMs>
-    void from_variant(const fc::variant &v, eosio::chain::block_timestamp<IntervalMs, EpochMs> &t) {
-        t = v.as<fc::time_point>();
-    }
+  template<uint16_t IntervalMs, uint64_t EpochMs>
+  void from_variant(const fc::variant& v, eosio::chain::block_timestamp<IntervalMs,EpochMs>& t) {
+     t = v.as<fc::time_point>();
+  }
 }
 
 #ifdef _MSC_VER
-#pragma warning (pop)
+  #pragma warning (pop)
 #endif /// #ifdef _MSC_VER

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -167,16 +167,15 @@ namespace eosio {
              *
              */
             transaction_trace_ptr push_transaction(const transaction_metadata_ptr &trx, fc::time_point deadline,
-                                                   uint32_t billed_cpu_time_us = 0);
+                                                   uint32_t billed_cpu_time_us, bool explicit_billed_cpu_time);
 
             /**
              * Attempt to execute a specific transaction in our deferred trx database
              *
              */
-            transaction_trace_ptr
-            push_scheduled_transaction(const transaction_id_type &scheduled, fc::time_point deadline,
-                                       uint32_t billed_cpu_time_us = 0);
-
+             transaction_trace_ptr push_scheduled_transaction( const transaction_id_type& scheduled, fc::time_point deadline,
+                                                                uint32_t billed_cpu_time_us, bool explicit_billed_cpu_time );
+                                                                
             block_state_ptr finalize_block(const std::function<signature_type(const digest_type &)> &signer_callback);
 
             void sign_block(const std::function<signature_type(const digest_type &)> &signer_callback);

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -103,8 +103,8 @@ namespace eosio {
 
             void record_transaction(const transaction_id_type &id, fc::time_point_sec expire);
 
-            void validate_cpu_usage_to_bill(int64_t u, bool check_minimum = true) const;
-
+            void validate_cpu_usage_to_bill( int64_t billed_us, int64_t account_cpu_limit, bool check_minimum )const;
+            void validate_account_cpu_usage( int64_t billed_us, int64_t account_cpu_limit, bool estimate )const;
             void disallow_transaction_extensions(const char *error_msg) const;
 
             /// Fields:

--- a/libraries/chain/include/eosio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_metadata.hpp
@@ -38,7 +38,7 @@ namespace eosio {
             bool accepted = false;
             bool implicit = false;
             bool scheduled = false;
-
+            uint32_t billed_cpu_time_us = 0;
             transaction_metadata() = delete;
 
             transaction_metadata(const transaction_metadata &) = delete;

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -229,9 +229,8 @@ namespace eosio {
 
             initial_objective_duration_limit = objective_duration_limit;
 
-            if (billed_cpu_time_us > 0) // could also call on explicit_billed_cpu_time but it would be redundant
-                validate_cpu_usage_to_bill(billed_cpu_time_us,
-                                           false); // Fail early if the amount to be billed is too high
+            if( explicit_billed_cpu_time )
+                    validate_cpu_usage_to_bill( billed_cpu_time_us, std::numeric_limits<int64_t>::max(), false ); // Fail early if the amount to be billed is too high
 
             // Record accounts to be billed for network and CPU usage
             if (control.is_builtin_activated(builtin_protocol_feature_t::only_bill_first_authorizer)) {
@@ -281,6 +280,11 @@ namespace eosio {
                 deadline_exception_code = deadline_exception::code_value;
             } else {
                 deadline_exception_code = billing_timer_exception_code;
+            }
+
+            if( !explicit_billed_cpu_time ) {
+                // if account no longer has enough cpu to exec trx, don't try
+                validate_account_cpu_usage( billed_cpu_time_us, account_cpu_limit, true );
             }
 
             eager_net_limit = (eager_net_limit / 8) *
@@ -441,7 +445,7 @@ namespace eosio {
 
             update_billed_cpu_time(now);
 
-            validate_cpu_usage_to_bill(billed_cpu_time_us);
+            validate_cpu_usage_to_bill( billed_cpu_time_us, account_cpu_limit, true );
 
             rl.add_transaction_usage(bill_to_accounts, static_cast<uint64_t>(billed_cpu_time_us), net_usage,
                                      block_timestamp_type(control.pending_block_time()).slot); // Should never fail
@@ -541,7 +545,7 @@ namespace eosio {
             _deadline_timer.start(_deadline);
         }
 
-        void transaction_context::validate_cpu_usage_to_bill(int64_t billed_us, bool check_minimum) const {
+void transaction_context::validate_cpu_usage_to_bill( int64_t billed_us, int64_t account_cpu_limit, bool check_minimum )const {
 
             EOS_ASSERT(billed_us <= control.get_global_properties().configuration.max_transaction_cpu_usage,
                      block_cpu_usage_exceeded,
@@ -558,18 +562,27 @@ namespace eosio {
                     );
                 }
 
-                if (billing_timer_exception_code == block_cpu_usage_exceeded::code_value) {
+                validate_account_cpu_usage( billed_us, account_cpu_limit, false );
+              }
+           }
+
+           void transaction_context::validate_account_cpu_usage( int64_t billed_us, int64_t account_cpu_limit, bool estimate )const {
+             if( (billed_us > 0) && !control.skip_trx_checks() ) {
+               const bool cpu_limited_by_account = (account_cpu_limit <= objective_duration_limit.count());
+
+               if( !cpu_limited_by_account && (billing_timer_exception_code == block_cpu_usage_exceeded::code_value) ) {
+
                     EOS_ASSERT(billed_us <= objective_duration_limit.count(),
                                block_cpu_usage_exceeded,
-                               "billed CPU time (${billed} us) is greater than the billable CPU time left in the block (${billable} us)",
-                               ("billed", billed_us)("billable", objective_duration_limit.count())
-                    );
+                               "${desc} CPU time (${billed} us) is greater than the billable CPU time left in the block (${billable} us)",
+                               ("desc", (estimate ? "estimated" : "billed"))("billed", billed_us)( "billable", objective_duration_limit.count() )
+                   );
                 } else {
-                    if (cpu_limit_due_to_greylist) {
-                        EOS_ASSERT(billed_us <= objective_duration_limit.count(),
+                  if( cpu_limit_due_to_greylist && cpu_limited_by_account ) {
+                     EOS_ASSERT( billed_us <= account_cpu_limit,
                                    greylist_cpu_usage_exceeded,
-                                   "billed CPU time (${billed} us) is greater than the maximum greylisted billable CPU time for the transaction (${billable} us)",
-                                   ("billed", billed_us)("billable", objective_duration_limit.count())
+                                   "${desc} CPU time (${billed} us) is greater than the maximum greylisted billable CPU time for the transaction (${billable} us)",
+                                   ("desc", (estimate ? "estimated" : "billed"))("billed", billed_us)( "billable", account_cpu_limit )
                         );
                     } else {
                         EOS_ASSERT(billed_us <= objective_duration_limit.count(),
@@ -633,6 +646,8 @@ namespace eosio {
                     greylisted_cpu |= cpu_was_greylisted;
                 }
             }
+            EOS_ASSERT( (!force_elastic_limits && control.is_producing_block()) || (!greylisted_cpu && !greylisted_net),
+                        transaction_exception, "greylisted when not producing block" );
 
             return std::make_tuple(account_net_limit, account_cpu_limit, greylisted_net, greylisted_cpu);
         }

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -256,7 +256,7 @@ namespace eosio {
                 unapplied_transactions_type unapplied_trxs = control->get_unapplied_transactions(); // make copy of map
                 for (const auto &entry : unapplied_trxs) {
                     auto trace = control->push_transaction(entry.second, fc::time_point::maximum(),
-                                                           DEFAULT_BILLED_CPU_TIME_US);
+                                                           DEFAULT_BILLED_CPU_TIME_US, true);
                     if (trace->except) {
                         trace->except->dynamic_rethrow_exception();
                     }
@@ -266,7 +266,7 @@ namespace eosio {
                 while ((scheduled_trxs = get_scheduled_transactions()).size() > 0) {
                     for (const auto &trx : scheduled_trxs) {
                         auto trace = control->push_scheduled_transaction(trx, fc::time_point::maximum(),
-                                                                         DEFAULT_BILLED_CPU_TIME_US);
+                                                                         DEFAULT_BILLED_CPU_TIME_US, true);
                         if (trace->except) {
                             trace->except->dynamic_rethrow_exception();
                         }
@@ -467,7 +467,7 @@ namespace eosio {
                                   fc::microseconds(deadline - fc::time_point::now());
                 transaction_metadata::start_recover_keys(mtrx, control->get_thread_pool(), control->get_chain_id(),
                                                          time_limit);
-                auto r = control->push_transaction(mtrx, deadline, billed_cpu_time_us);
+                auto r = control->push_transaction(mtrx, deadline, billed_cpu_time_us, billed_cpu_time_us > 0);
                 if (r->except_ptr) std::rethrow_exception(r->except_ptr);
                 if (r->except) throw *r->except;
                 return r;
@@ -495,7 +495,7 @@ namespace eosio {
                 auto mtrx = std::make_shared<transaction_metadata>(trx, c);
                 transaction_metadata::start_recover_keys(mtrx, control->get_thread_pool(), control->get_chain_id(),
                                                          time_limit);
-                auto r = control->push_transaction(mtrx, deadline, billed_cpu_time_us);
+                auto r = control->push_transaction(mtrx, deadline, billed_cpu_time_us, billed_cpu_time_us > 0);
                 if (no_throw) return r;
                 if (r->except_ptr) std::rethrow_exception(r->except_ptr);
                 if (r->except) throw *r->except;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -81,7 +81,7 @@ using namespace eosio::chain;
 using namespace eosio::chain::plugin_interface;
 
 namespace {
-   bool failure_is_subjective(const fc::exception& e, bool deadline_is_subjective) {
+   bool exception_is_exhausted(const fc::exception& e, bool deadline_is_subjective) {
       auto code = e.code();
       return (code == block_cpu_usage_exceeded::code_value) ||
              (code == block_net_usage_exceeded::code_value) ||
@@ -486,9 +486,9 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
          }
 
          try {
-            auto trace = chain.push_transaction(trx, deadline);
+            auto trace = chain.push_transaction(trx, deadline, trx->billed_cpu_time_us, false );
             if (trace->except) {
-               if (failure_is_subjective(*trace->except, deadline_is_subjective)) {
+               if (exception_is_exhausted(*trace->except, deadline_is_subjective)) {
                   _pending_incoming_transactions.emplace_back(trx, persist_until_expired, next);
                   if (_pending_block_mode == pending_block_mode::producing) {
                      fc_dlog(_trx_trace_log, "[TRX_TRACE] Block ${block_num} for producer ${prod} COULD NOT FIT, tx: ${txid} RETRYING ",
@@ -1602,9 +1602,9 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
                      trx_deadline = deadline;
                   }
 
-                  auto trace = chain.push_transaction(trx, trx_deadline);
+                  auto trace = chain.push_transaction(trx, trx_deadline, trx->billed_cpu_time_us, false);
                   if (trace->except) {
-                     if (failure_is_subjective(*trace->except, deadline_is_subjective)) {
+                     if (exception_is_exhausted(*trace->except, deadline_is_subjective)) {
                         exhausted = true;
                         break;
                      } else {
@@ -1647,15 +1647,16 @@ bool producer_plugin_impl::process_scheduled_and_incoming_trxs( const fc::time_p
    auto sch_itr = sch_idx.begin();
    while( sch_itr != sch_idx.end() ) {
       if( sch_itr->delay_until > pending_block_time) break;    // not scheduled yet
-      if( sch_itr->published >= pending_block_time ) {
-         ++sch_itr;
-         continue; // do not allow schedule and execute in same block
-      }
+
       if( deadline <= fc::time_point::now() ) {
          exhausted = true;
          break;
       }
 
+      if( sch_itr->published >= pending_block_time ) {
+         ++sch_itr;
+         continue; // do not allow schedule and execute in same block
+      }
       const transaction_id_type trx_id = sch_itr->trx_id; // make copy since reference could be invalidated
       if (blacklist_by_id.find(trx_id) != blacklist_by_id.end()) {
          ++sch_itr;
@@ -1696,11 +1697,10 @@ bool producer_plugin_impl::process_scheduled_and_incoming_trxs( const fc::time_p
             trx_deadline = deadline;
          }
 
-         auto trace = chain.push_scheduled_transaction(trx_id, trx_deadline);
+         auto trace = chain.push_scheduled_transaction(trx_id, trx_deadline, 0, false);
          if (trace->except) {
-            if (failure_is_subjective(*trace->except, deadline_is_subjective)) {
-               exhausted = true;
-               break;
+            if (exception_is_exhausted(*trace->except, deadline_is_subjective)) {
+              //do not blacklist
             } else {
                auto expiration = fc::time_point::now() + fc::seconds(chain.get_global_properties().configuration.deferred_trx_expiration_window);
                // this failed our configured maximum transaction time, we don't want to replay it add it to a blacklist

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -200,12 +200,14 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
 
       optional<fc::time_point> calculate_next_block_time(const account_name& producer_name, const block_timestamp_type& current_block_time) const;
       void schedule_production_loop();
+      bool block_is_exhausted() const;
+      void schedule_maybe_produce_block( bool exhausted );
       void produce_block();
       bool maybe_produce_block();
       bool remove_expired_persisted_trxs( const fc::time_point& deadline );
       bool remove_expired_blacklisted_trxs( const fc::time_point& deadline );
       bool process_unapplied_trxs( const fc::time_point& deadline );
-      bool process_scheduled_and_incoming_trxs( const fc::time_point& deadline, size_t& orig_pending_txn_size );
+      void process_scheduled_and_incoming_trxs( const fc::time_point& deadline, size_t& orig_pending_txn_size );
       bool process_incoming_trxs( const fc::time_point& deadline, size_t& orig_pending_txn_size );
 
       boost::program_options::variables_map _options;
@@ -222,11 +224,13 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       transaction_id_with_expiry_index                          _persistent_transactions;
       fc::optional<named_thread_pool>                           _thread_pool;
 
-      int32_t                                                   _max_transaction_time_ms;
+      int32_t                                                   _max_transaction_time_ms = 0;
       fc::microseconds                                          _max_irreversible_block_age_us;
       int32_t                                                   _produce_time_offset_us = 0;
       int32_t                                                   _last_block_time_offset_us = 0;
-      int32_t                                                   _max_scheduled_transaction_time_per_block_ms;
+      uint32_t                                                  _max_block_cpu_usage_threshold_us = 0;
+      uint32_t                                                  _max_block_net_usage_threshold_bytes = 0;
+      int32_t                                                   _max_scheduled_transaction_time_per_block_ms = 0;
       fc::time_point                                            _irreversible_block_time;
       fc::microseconds                                          _keosd_provider_timeout_us;
 
@@ -423,16 +427,21 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
             if( future.valid() )
                future.wait();
             app().post(priority::low, [self, trx, persist_until_expired, next]() {
-               self->process_incoming_transaction_async( trx, persist_until_expired, next );
+              if( !self->process_incoming_transaction_async( trx, persist_until_expired, next ) ) {
+                if( self->_pending_block_mode == pending_block_mode::producing ) {
+                   self->schedule_maybe_produce_block( true );
+                }
+              };
             });
          });
       }
 
-      void process_incoming_transaction_async(const transaction_metadata_ptr& trx, bool persist_until_expired, next_function<transaction_trace_ptr> next) {
+      bool process_incoming_transaction_async(const transaction_metadata_ptr& trx, bool persist_until_expired, next_function<transaction_trace_ptr> next) {
+         bool exhausted = true;
          chain::controller& chain = chain_plug->chain();
          if (!chain.is_building_block()) {
             _pending_incoming_transactions.emplace_back(trx, persist_until_expired, next);
-            return;
+            return true;
          }
 
          auto block_time = chain.pending_block_time();
@@ -469,12 +478,12 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
          const auto& id = trx->id;
          if( fc::time_point(trx->packed_trx->expiration()) < block_time ) {
             send_response(std::static_pointer_cast<fc::exception>(std::make_shared<expired_tx_exception>(FC_LOG_MESSAGE(error, "expired transaction ${id}", ("id", id)) )));
-            return;
+            return true;
          }
 
          if( chain.is_known_unexpired_transaction(id) ) {
             send_response(std::static_pointer_cast<fc::exception>(std::make_shared<tx_duplicate>(FC_LOG_MESSAGE(error, "duplicate transaction ${id}", ("id", id)) )));
-            return;
+            return true;
          }
 
          auto deadline = fc::time_point::now() + fc::milliseconds(_max_transaction_time_ms);
@@ -499,6 +508,8 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                      fc_dlog(_trx_trace_log, "[TRX_TRACE] Speculative execution COULD NOT FIT tx: ${txid} RETRYING",
                              ("txid", trx->id));
                   }
+                  if (!exhausted)
+                    exhausted = block_is_exhausted();
                } else {
                   auto e_ptr = trace->except->dynamic_copy_exception();
                   send_response(e_ptr);
@@ -519,6 +530,8 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
          } catch ( std::bad_alloc& ) {
             chain_plugin::handle_bad_alloc();
          } CATCH_AND_CALL(send_response);
+
+         return !exhausted;
       }
 
 
@@ -547,6 +560,8 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
       fc::time_point calculate_pending_block_time() const;
       fc::time_point calculate_block_deadline( const fc::time_point& ) const;
       void schedule_delayed_production_loop(const std::weak_ptr<producer_plugin_impl>& weak_this, const block_timestamp_type& current_block_time);
+      optional<fc::time_point> calculate_producer_wake_up_time( const block_timestamp_type& ref_block_time ) const;
+
 };
 
 void new_chain_banner(const eosio::chain::controller& db)
@@ -616,6 +631,10 @@ void producer_plugin::set_program_options(
           "offset of non last block producing time in microseconds. Negative number results in blocks to go out sooner, and positive number results in blocks to go out later")
          ("last-block-time-offset-us", boost::program_options::value<int32_t>()->default_value(0),
           "offset of last block producing time in microseconds. Negative number results in blocks to go out sooner, and positive number results in blocks to go out later")
+         ("max-block-cpu-usage-threshold-us", bpo::value<uint32_t>()->default_value( 5000 ),
+          "Threshold of CPU block production to consider block full; when within threshold of max-block-cpu-usage block can be produced immediately")
+         ("max-block-net-usage-threshold-bytes", bpo::value<uint32_t>()->default_value( 1024 ),
+          "Threshold of NET block production to consider block full; when within threshold of max-block-net-usage block can be produced immediately")
          ("max-scheduled-transaction-time-per-block-ms", boost::program_options::value<int32_t>()->default_value(100),
           "Maximum wall-clock time, in milliseconds, spent retiring scheduled transactions in any block before returning to normal transaction processing.")
          ("subjective-cpu-leeway-us", boost::program_options::value<int32_t>()->default_value( config::default_subjective_cpu_leeway_us ),
@@ -1450,7 +1469,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
 
          if( app().is_quiting() ) // db guard exception above in LOG_AND_DROP could have called app().quit()
             return start_block_result::failed;
-         if( preprocess_deadline <= fc::time_point::now() ) {
+         if( preprocess_deadline <= fc::time_point::now() || block_is_exhausted()) {
             return start_block_result::exhausted;
          } else {
             if( !process_incoming_trxs( preprocess_deadline, pending_incoming_process_limit ) )
@@ -1605,8 +1624,11 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
                   auto trace = chain.push_transaction(trx, trx_deadline, trx->billed_cpu_time_us, false);
                   if (trace->except) {
                      if (exception_is_exhausted(*trace->except, deadline_is_subjective)) {
-                        exhausted = true;
-                        break;
+                        if (block_is_exhausted()) {
+                          exhausted = true;
+                          break;
+                        }
+                        // don't erase, block exhausted failure so try again next time
                      } else {
                         // this failed our configured maximum transaction time, we don't want to replay it
                         // chain.plus_transactions can modify unapplied_trxs, so erase by id
@@ -1629,7 +1651,7 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
    return !exhausted;
 }
 
-bool producer_plugin_impl::process_scheduled_and_incoming_trxs( const fc::time_point& deadline, size_t& pending_incoming_process_limit )
+void producer_plugin_impl::process_scheduled_and_incoming_trxs( const fc::time_point& deadline, size_t& pending_incoming_process_limit )
 {
    chain::controller& chain = chain_plug->chain();
    const time_point pending_block_time = chain.pending_block_time();
@@ -1648,7 +1670,7 @@ bool producer_plugin_impl::process_scheduled_and_incoming_trxs( const fc::time_p
    while( sch_itr != sch_idx.end() ) {
       if( sch_itr->delay_until > pending_block_time) break;    // not scheduled yet
 
-      if( deadline <= fc::time_point::now() ) {
+      if( exhausted || deadline <= fc::time_point::now() ) {
          exhausted = true;
          break;
       }
@@ -1681,10 +1703,13 @@ bool producer_plugin_impl::process_scheduled_and_incoming_trxs( const fc::time_p
          _pending_incoming_transactions.pop_front();
          --pending_incoming_process_limit;
          incoming_trx_weight -= 1.0;
-         process_incoming_transaction_async(std::get<0>(e), std::get<1>(e), std::get<2>(e));
+         if( !process_incoming_transaction_async(std::get<0>(e), std::get<1>(e), std::get<2>(e)) ) {
+            exhausted = true;
+            break;
+         }
       }
 
-      if (deadline <= fc::time_point::now()) {
+      if (exhausted || deadline <= fc::time_point::now()) {
          exhausted = true;
          break;
       }
@@ -1700,7 +1725,10 @@ bool producer_plugin_impl::process_scheduled_and_incoming_trxs( const fc::time_p
          auto trace = chain.push_scheduled_transaction(trx_id, trx_deadline, 0, false);
          if (trace->except) {
             if (exception_is_exhausted(*trace->except, deadline_is_subjective)) {
-              //do not blacklist
+              if( block_is_exhausted() ) {
+                 exhausted = true;
+                 break;
+              }
             } else {
                auto expiration = fc::time_point::now() + fc::seconds(chain.get_global_properties().configuration.deferred_trx_expiration_window);
                // this failed our configured maximum transaction time, we don't want to replay it add it to a blacklist
@@ -1723,7 +1751,7 @@ bool producer_plugin_impl::process_scheduled_and_incoming_trxs( const fc::time_p
       fc_dlog( _log, "Processed ${m} of ${n} scheduled transactions, Applied ${applied}, Failed/Dropped ${failed}",
                ( "m", num_processed )( "n", scheduled_trxs_size )( "applied", num_applied )( "failed", num_failed ) );
    }
-   return !exhausted;
+
 }
 
 bool producer_plugin_impl::process_incoming_trxs( const fc::time_point& deadline, size_t& pending_incoming_process_limit )
@@ -1739,12 +1767,32 @@ bool producer_plugin_impl::process_incoming_trxs( const fc::time_point& deadline
          auto e = _pending_incoming_transactions.front();
          _pending_incoming_transactions.pop_front();
          --pending_incoming_process_limit;
-         process_incoming_transaction_async(std::get<0>(e), std::get<1>(e), std::get<2>(e));
+         if( !process_incoming_transaction_async(std::get<0>(e), std::get<1>(e), std::get<2>(e)) ) {
+            exhausted = true;
+            break;
+         }
       }
    }
    return !exhausted;
 }
 
+bool producer_plugin_impl::block_is_exhausted() const {
+   const chain::controller& chain = chain_plug->chain();
+   const auto& rl = chain.get_resource_limits_manager();
+
+   const uint64_t cpu_limit = rl.get_block_cpu_limit();
+   if( cpu_limit < _max_block_cpu_usage_threshold_us ) return true;
+   const uint64_t net_limit = rl.get_block_net_limit();
+   if( net_limit < _max_block_net_usage_threshold_bytes ) return true;
+   return false;
+}
+
+// Example:
+// --> Start block A (block time x.500) at time x.000
+// -> start_block()
+// --> deadline, produce block x.500 at time x.400 (assuming 80% cpu block effort)
+// -> Idle
+// --> Start block B (block time y.000) at time x.500
 void producer_plugin_impl::schedule_production_loop() {
    chain::controller& chain = chain_plug->chain();
    _timer.cancel();
@@ -1758,7 +1806,7 @@ void producer_plugin_impl::schedule_production_loop() {
 
       // we failed to start a block, so try again later?
       _timer.async_wait( app().get_priority_queue().wrap( priority::high,
-          [weak_this, cid = ++_timer_corelation_id]( const boost::system::error_code& ec ) {
+          [weak_this = weak_from_this(), cid = ++_timer_corelation_id]( const boost::system::error_code& ec ) {
              auto self = weak_this.lock();
              if( self && ec != boost::asio::error::operation_aborted && cid == self->_timer_corelation_id ) {
                 self->schedule_production_loop();
@@ -1767,57 +1815,56 @@ void producer_plugin_impl::schedule_production_loop() {
    } else if (result == start_block_result::waiting){
       if (!_producers.empty() && !production_disabled_by_policy()) {
          fc_dlog(_log, "Waiting till another block is received and scheduling Speculative/Production Change");
-         schedule_delayed_production_loop(weak_this, calculate_pending_block_time());
+ schedule_delayed_production_loop(weak_from_this(), calculate_producer_wake_up_time(calculate_pending_block_time()));
       } else {
          fc_dlog(_log, "Waiting till another block is received");
          // nothing to do until more blocks arrive
       }
 
    } else if (_pending_block_mode == pending_block_mode::producing) {
+      schedule_maybe_produce_block( result == start_block_result::exhausted );
 
-      // we succeeded but block may be exhausted
-      static const boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
-      auto deadline = calculate_block_deadline(chain.pending_block_time());
-
-      if (deadline > fc::time_point::now()) {
-         // ship this block off no later than its deadline
-         EOS_ASSERT( chain.is_building_block(), missing_pending_block_state, "producing without pending_block_state, start_block succeeded" );
-         _timer.expires_at( epoch + boost::posix_time::microseconds( deadline.time_since_epoch().count() ));
-         fc_dlog(_log, "Scheduling Block Production on Normal Block #${num} for ${time}",
-                       ("num", chain.head_block_num()+1)("time",deadline));
-      } else {
-         EOS_ASSERT( chain.is_building_block(), missing_pending_block_state, "producing without pending_block_state" );
-         auto expect_time = chain.pending_block_time() - fc::microseconds(config::block_interval_us);
-         // ship this block off up to 1 block time earlier or immediately
-         if (fc::time_point::now() >= expect_time) {
-            _timer.expires_from_now( boost::posix_time::microseconds( 0 ));
-            fc_dlog(_log, "Scheduling Block Production on Exhausted Block #${num} immediately",
-                          ("num", chain.head_block_num()+1));
-         } else {
-            _timer.expires_at(epoch + boost::posix_time::microseconds(expect_time.time_since_epoch().count()));
-            fc_dlog(_log, "Scheduling Block Production on Exhausted Block #${num} at ${time}",
-                          ("num", chain.head_block_num()+1)("time",expect_time));
-         }
-      }
-
-      _timer.async_wait( app().get_priority_queue().wrap( priority::high,
-            [&chain,weak_this,cid=++_timer_corelation_id](const boost::system::error_code& ec) {
-               auto self = weak_this.lock();
-               if( self && ec != boost::asio::error::operation_aborted && cid == self->_timer_corelation_id ) {
-                  fc_dlog( _log, "Produce block timer running at ${time}", ("time", fc::time_point::now()) );
-                  // pending_block_state expected, but can't assert inside async_wait
-                  auto block_num = chain.is_building_block() ? chain.head_block_num() + 1 : 0;
-                  auto res = self->maybe_produce_block();
-                  fc_dlog( _log, "Producing Block #${num} returned: ${res}", ("num", block_num)( "res", res ) );
-               }
-            } ) );
    } else if (_pending_block_mode == pending_block_mode::speculating && !_producers.empty() && !production_disabled_by_policy()){
       fc_dlog(_log, "Speculative Block Created; Scheduling Speculative/Production Change");
       EOS_ASSERT( chain.is_building_block(), missing_pending_block_state, "speculating without pending_block_state" );
-      schedule_delayed_production_loop(weak_this, chain.pending_block_time());
+ schedule_delayed_production_loop(weak_from_this(), calculate_producer_wake_up_time(chain.pending_block_time()));
    } else {
       fc_dlog(_log, "Speculative Block Created");
    }
+}
+
+void producer_plugin_impl::schedule_maybe_produce_block( bool exhausted ) {
+   chain::controller& chain = chain_plug->chain();
+
+   // we succeeded but block may be exhausted
+   static const boost::posix_time::ptime epoch( boost::gregorian::date( 1970, 1, 1 ) );
+   auto deadline = calculate_block_deadline( chain.pending_block_time() );
+
+   if( !exhausted && deadline > fc::time_point::now() ) {
+      // ship this block off no later than its deadline
+      EOS_ASSERT( chain.is_building_block(), missing_pending_block_state,
+                  "producing without pending_block_state, start_block succeeded" );
+      _timer.expires_at( epoch + boost::posix_time::microseconds( deadline.time_since_epoch().count() ) );
+      fc_dlog( _log, "Scheduling Block Production on Normal Block #${num} for ${time}",
+               ("num", chain.head_block_num() + 1)( "time", deadline ) );
+   } else {
+      EOS_ASSERT( chain.is_building_block(), missing_pending_block_state, "producing without pending_block_state" );
+      _timer.expires_from_now( boost::posix_time::microseconds( 0 ) );
+      fc_dlog( _log, "Scheduling Block Production on ${desc} Block #${num} immediately",
+               ("num", chain.head_block_num() + 1)("desc", block_is_exhausted() ? "Exhausted" : "Deadline exceeded") );
+   }
+
+   _timer.async_wait( app().get_priority_queue().wrap( priority::high,
+         [&chain, weak_this = weak_from_this(), cid=++_timer_corelation_id](const boost::system::error_code& ec) {
+            auto self = weak_this.lock();
+            if( self && ec != boost::asio::error::operation_aborted && cid == self->_timer_corelation_id ) {
+               // pending_block_state expected, but can't assert inside async_wait
+               auto block_num = chain.is_building_block() ? chain.head_block_num() + 1 : 0;
+               fc_dlog( _log, "Produce block timer for ${num} running at ${time}", ("num", block_num)("time", fc::time_point::now()) );
+               auto res = self->maybe_produce_block();
+               fc_dlog( _log, "Producing Block #${num} returned: ${res}", ("num", block_num)( "res", res ) );
+            }
+         } ) );
 }
 
 void producer_plugin_impl::schedule_delayed_production_loop(const std::weak_ptr<producer_plugin_impl>& weak_this, const block_timestamp_type& current_block_time) {

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1260,7 +1260,7 @@ BOOST_AUTO_TEST_SUITE(api_tests)
                 auto dtrxs = get_scheduled_transactions();
                 BOOST_CHECK_EQUAL(dtrxs.size(), 1);
                 for (const auto &trx: dtrxs) {
-                    control->push_scheduled_transaction(trx, fc::time_point::maximum());
+                    control->push_scheduled_transaction(trx, fc::time_point::maximum(), 0, false);
                 }
                 BOOST_CHECK_EQUAL(1, count);
                 BOOST_REQUIRE(trace);
@@ -1287,10 +1287,11 @@ BOOST_AUTO_TEST_SUITE(api_tests)
                 produce_blocks(3);
 
                 //check that only one deferred transaction executed
+                auto billed_cpu_time_us = control->get_global_properties().configuration.min_transaction_cpu_usage;                
                 auto dtrxs = get_scheduled_transactions();
                 BOOST_CHECK_EQUAL(dtrxs.size(), 1);
                 for (const auto &trx: dtrxs) {
-                    control->push_scheduled_transaction(trx, fc::time_point::maximum());
+                    control->push_scheduled_transaction(trx, fc::time_point::maximum(), billed_cpu_time_us, true);
                 }
                 BOOST_CHECK_EQUAL(1, count);
                 BOOST_CHECK(trace);

--- a/unittests/delay_tests.cpp
+++ b/unittests/delay_tests.cpp
@@ -82,7 +82,9 @@ BOOST_AUTO_TEST_SUITE(delay_tests)
             auto scheduled_trxs = get_scheduled_transactions();
             BOOST_REQUIRE_EQUAL(scheduled_trxs.size(), 1u);
 
-            auto dtrace = control->push_scheduled_transaction(scheduled_trxs.front(), fc::time_point::maximum());
+            auto billed_cpu_time_us = control->get_global_properties().configuration.min_transaction_cpu_usage;
+            auto dtrace = control->push_scheduled_transaction(scheduled_trxs.front(), fc::time_point::maximum(), billed_cpu_time_us, true);
+
             BOOST_REQUIRE_EQUAL(dtrace->except.valid(), true);
             BOOST_REQUIRE_EQUAL(dtrace->except->code(), missing_auth_exception::code_value);
 

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -7,6 +7,7 @@
 
 #include <eosio/chain/abi_serializer.hpp>
 #include <eosio/chain/exceptions.hpp>
+#include <eosio/chain/global_property_object.hpp>
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/wasm_eosio_constraints.hpp>
 #include <eosio/chain/wast_to_wasm.hpp>
@@ -1789,6 +1790,143 @@ BOOST_AUTO_TEST_SUITE(wasm_tests)
         push_transaction(trx);
         produce_blocks(1);
     } FC_LOG_AND_RETHROW()
+
+    BOOST_AUTO_TEST_CASE( billed_cpu_test ) try {
+
+       tester chain;
+
+       const resource_limits_manager& mgr = chain.control->get_resource_limits_manager();
+
+       account_name acc = N( asserter );
+       account_name user = N( user );
+       chain.create_accounts( {acc, user} );
+       chain.produce_block();
+
+       auto create_trx = [&](auto trx_max_ms) {
+          signed_transaction trx;
+          trx.actions.emplace_back( vector<permission_level>{{acc, config::active_name}},
+                                    assertdef {1, "Should Not Assert!"} );
+          static int num_secs = 1;
+          chain.set_transaction_headers( trx, ++num_secs ); // num_secs provides nonce
+          trx.max_cpu_usage_ms = trx_max_ms;
+          trx.sign( chain.get_private_key( acc, "active" ), chain.control->get_chain_id() );
+          auto mtrx = std::make_shared<transaction_metadata>( std::make_shared<packed_transaction>(trx) );
+          transaction_metadata::start_recover_keys( mtrx, chain.control->get_thread_pool(), chain.control->get_chain_id(), fc::microseconds::maximum() );
+          return mtrx;
+       };
+
+       auto push_trx = [&]( const transaction_metadata_ptr& trx, fc::time_point deadline,
+                         uint32_t billed_cpu_time_us, bool explicit_billed_cpu_time ) {
+          auto r = chain.control->push_transaction( trx, deadline, billed_cpu_time_us, explicit_billed_cpu_time );
+          if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
+          if( r->except ) throw *r->except;
+          return r;
+       };
+
+       auto ptrx = create_trx(0);
+       // no limits, just verifying trx works
+       push_trx( ptrx, fc::time_point::maximum(), 0, false ); // non-explicit billing
+
+       // setup account acc with large limits
+       chain.push_action( config::system_account_name, N(setalimits), config::system_account_name, fc::mutable_variant_object()
+             ("account", user)
+             ("ram_bytes", -1)
+             ("net_weight", 19'999'999)
+             ("cpu_weight", 19'999'999)
+       );
+       chain.push_action( config::system_account_name, N(setalimits), config::system_account_name, fc::mutable_variant_object()
+             ("account", acc)
+             ("ram_bytes", -1)
+             ("net_weight", 9'999)
+             ("cpu_weight", 9'999)
+       );
+
+       chain.produce_block();
+
+       auto max_cpu_time_us = chain.control->get_global_properties().configuration.max_transaction_cpu_usage;
+       auto min_cpu_time_us = chain.control->get_global_properties().configuration.min_transaction_cpu_usage;
+
+       auto cpu_limit = mgr.get_account_cpu_limit(acc).first; // huge limit ~17s
+
+       ptrx = create_trx(0);
+       BOOST_CHECK_LT( max_cpu_time_us, cpu_limit ); // max_cpu_time_us has to be less than cpu_limit to actually test max and not account
+       // indicate explicit billing at transaction max, max_cpu_time_us has to be greater than account cpu time
+       push_trx( ptrx, fc::time_point::maximum(), max_cpu_time_us, true );
+       chain.produce_block();
+
+       cpu_limit = mgr.get_account_cpu_limit(acc).first;
+
+       // do not allow to bill greater than chain configured max, objective failure even with explicit billing for over max
+       ptrx = create_trx(0);
+       BOOST_CHECK_LT( max_cpu_time_us + 1, cpu_limit ); // max_cpu_time_us+1 has to be less than cpu_limit to actually test max and not account
+       // indicate explicit billing at max + 1
+       BOOST_CHECK_EXCEPTION( push_trx( ptrx, fc::time_point::maximum(), max_cpu_time_us + 1, true ), tx_cpu_usage_exceeded,
+                              fc_exception_message_starts_with( "billed") );
+
+       // allow to bill at trx configured max
+       ptrx = create_trx(5); // set trx max at 5ms
+       BOOST_CHECK_LT( 5 * 1000, cpu_limit ); // 5ms has to be less than cpu_limit to actually test trx max and not account
+       // indicate explicit billing at max
+       push_trx( ptrx, fc::time_point::maximum(), 5 * 1000, true );
+       chain.produce_block();
+
+       cpu_limit = mgr.get_account_cpu_limit(acc).first; // update after last trx
+
+       // do not allow to bill greater than trx configured max, objective failure even with explicit billing for over max
+       ptrx = create_trx(5); // set trx max at 5ms
+       BOOST_CHECK_LT( 5 * 1000 + 1, cpu_limit ); // 5ms has to be less than cpu_limit to actually test trx max and not account
+       // indicate explicit billing at max + 1
+       BOOST_CHECK_EXCEPTION( push_trx( ptrx, fc::time_point::maximum(), 5 * 1000 + 1, true ), tx_cpu_usage_exceeded,
+                              fc_exception_message_starts_with("billed") );
+
+       // bill at minimum
+       ptrx = create_trx(0);
+       // indicate explicit billing at transaction minimum
+       push_trx( ptrx, fc::time_point::maximum(), min_cpu_time_us, true );
+       chain.produce_block();
+
+       // do not allow to bill less than minimum
+       ptrx = create_trx(0);
+       // indicate explicit billing at minimum-1, objective failure even with explicit billing for under min
+       BOOST_CHECK_EXCEPTION( push_trx( ptrx, fc::time_point::maximum(), min_cpu_time_us - 1, true ), transaction_exception,
+                              fc_exception_message_starts_with("cannot bill CPU time less than the minimum") );
+
+       chain.push_action( config::system_account_name, N(setalimits), config::system_account_name, fc::mutable_variant_object()
+             ("account", acc)
+             ("ram_bytes", -1)
+             ("net_weight", 75)
+             ("cpu_weight", 75) // ~130ms
+       );
+
+       chain.produce_block();
+       chain.produce_block( fc::days(1) ); // produce for one day to reset account cpu
+
+       cpu_limit = mgr.get_account_cpu_limit_ex(acc).first.max;
+
+       ptrx = create_trx(0);
+       BOOST_CHECK_LT( cpu_limit+1, max_cpu_time_us ); // needs to be less or this just tests the same thing as max_cpu_time_us test above
+       // indicate non-explicit billing with 1 more than our account cpu limit, triggers optimization check #8638 and fails trx
+       BOOST_CHECK_EXCEPTION( push_trx( ptrx, fc::time_point::maximum(), cpu_limit+1, false ), tx_cpu_usage_exceeded,
+                              fc_exception_message_starts_with("estimated") );
+
+       ptrx = create_trx(0);
+       BOOST_CHECK_LT( cpu_limit, max_cpu_time_us );
+       // indicate non-explicit billing at our account cpu limit, will allow this trx to run, but only bills for actual use
+       auto r = push_trx( ptrx, fc::time_point::maximum(), cpu_limit, false );
+       BOOST_CHECK_LT( r->receipt->cpu_usage_us, cpu_limit ); // verify not billed at provided bill amount when explicit_billed_cpu_time=false
+
+       chain.produce_block();
+       chain.produce_block( fc::days(1) ); // produce for one day to reset account cpu
+
+       ptrx = create_trx(0);
+       BOOST_CHECK_LT( cpu_limit+1, max_cpu_time_us ); // needs to be less or this just tests the same thing as max_cpu_time_us test above
+       // indicate explicit billing at over our account cpu limit, not allowed
+       cpu_limit = mgr.get_account_cpu_limit_ex(acc).first.max;
+       BOOST_CHECK_EXCEPTION( push_trx( ptrx, fc::time_point::maximum(), cpu_limit+1, true ), tx_cpu_usage_exceeded,
+                              fc_exception_message_starts_with("billed") );
+
+    } FC_LOG_AND_RETHROW()
+
 
 // TODO: restore net_usage_tests
 #if 0


### PR DESCRIPTION
## Change Description
### Integration based on EOSIO PR# 8678: 
- Check to make sure account has enough cpu to execute already executed transactions. Do not attempt to execute if not enough account cpu.
- v1.8.x version of #8638
- Not integrating changes into resource limits: https://github.com/EOSIO/eos/pull/8678/commits/b3fa9100a9cca235254e5d0e2397acb845d72dee

