### PR TITLE
Step 1: Migrate Request and OBT tables to temp index tables. 

### DIFF
--- a/fio.contracts/contracts/fio.request.obt/fio.request.obt.abi
+++ b/fio.contracts/contracts/fio.request.obt/fio.request.obt.abi
@@ -47,6 +47,56 @@
          }
       ]
     },{
+                            "name": "fioreqctxt2",
+                            "base": "",
+                            "fields": [{
+                                "name": "fio_request_id",
+                                "type": "uint64"
+                              },{
+                                "name": "payer_fio_addr_hex",
+                                "type": "uint128"
+                              },{
+                                "name": "payee_fio_addr_hex",
+                                "type": "uint128"
+                              },{
+                                "name": "content",
+                                "type": "string"
+                              },{
+                                "name": "time_stamp",
+                                "type": "uint64"
+                              },{
+                                "name": "payer_fio_addr",
+                                "type": "string"
+                              },{
+                                "name": "payee_fio_addr",
+                                "type": "string"
+                               },{
+                                "name": "payer_key",
+                                "type": "string"
+                               },{
+                                "name": "payee_key",
+                                "type": "string"
+                               },{
+                                "name": "payer_key_hex",
+                                "type": "uint128"
+                              },{
+                                "name": "payee_key_hex",
+                                "type": "uint128"
+                              },{
+                                "name": "futureuse_string1",
+                                "type": "string"
+                               },{
+                                "name": "futureuse_string2",
+                                "type": "string"
+                               },{
+                                "name": "futureuse_uint64",
+                                "type": "uint64"
+                              },{
+                                "name": "futureuse_uint128",
+                                "type": "uint128"
+                              }
+                            ]
+                          },{
             "name": "recordobt_info",
             "base": "",
             "fields": [{
@@ -91,6 +141,56 @@
                }
             ]
           },{
+            "name": "recobt_info2",
+            "base": "",
+            "fields": [{
+                "name": "id",
+                "type": "uint64"
+              },{
+                "name": "payer_fio_addr_hex",
+                "type": "uint128"
+              },{
+                "name": "payee_fio_addr_hex",
+                "type": "uint128"
+              },{
+                "name": "content",
+                "type": "string"
+              },{
+                "name": "time_stamp",
+                "type": "uint64"
+              },{
+                "name": "payer_fio_addr",
+                "type": "string"
+              },{
+                "name": "payee_fio_addr",
+                "type": "string"
+               },{
+                "name": "payer_key",
+                "type": "string"
+               },{
+                "name": "payee_key",
+                "type": "string"
+               },{
+                "name": "payer_key_hex",
+                "type": "uint128"
+              },{
+                "name": "payee_key_hex",
+                "type": "uint128"
+              },{
+                "name": "futureuse_string1",
+                "type": "string"
+               },{
+                "name": "futureuse_string2",
+                "type": "string"
+               },{
+                "name": "futureuse_uint64",
+                "type": "uint64"
+              },{
+                "name": "futureuse_uint128",
+                "type": "uint128"
+              }
+            ]
+          },{
       "name": "fioreqsts",
       "base": "",
       "fields": [{
@@ -111,6 +211,28 @@
         }
       ]
     },{
+                         "name": "migreqtxt",
+                             "base": "",
+                             "fields": [{
+                             "name": "amount",
+                             "type": "int16"
+                             },{
+                                         "name": "actor",
+                                         "type": "string"
+                                       }
+                               ]
+                         },{
+                                                    "name": "migobttxt",
+                                                        "base": "",
+                                                        "fields": [{
+                                                        "name": "amount",
+                                                        "type": "int16"
+                                                        },{
+                                                                   "name": "actor",
+                                                                   "type": "string"
+                                                                 }
+                                                          ]
+                                                    },{
       "name": "recordobt",
       "base": "",
       "fields": [{
@@ -196,6 +318,14 @@
          }
     ],
   "actions": [{
+                    "name": "migreqtxt",
+                    "type": "migreqtxt",
+                    "ricardian_contract": ""
+                    },{
+                                          "name": "migobttxt",
+                                          "type": "migobttxt",
+                                          "ricardian_contract": ""
+                                          },{
       "name": "recordobt",
       "type": "recordobt",
       "ricardian_contract": ""
@@ -224,6 +354,16 @@
       ],
       "type": "fioreqctxt"
     },{
+            "name": "fioreqctxts2",
+            "index_type": "i64",
+            "key_names": [
+              "fio_request_id"
+            ],
+            "key_types": [
+              "uint64"
+            ],
+            "type": "fioreqctxt2"
+          },{
             "name": "recordobts",
             "index_type": "i64",
             "key_names": [
@@ -234,6 +374,16 @@
             ],
             "type": "recordobt_info"
           },{
+                        "name": "recordobts2",
+                        "index_type": "i64",
+                        "key_names": [
+                          "id"
+                        ],
+                        "key_types": [
+                          "uint64"
+                        ],
+                        "type": "recobt_info2"
+                      },{
       "name": "fioreqstss",
       "index_type": "i64",
       "key_names": [

--- a/fio.contracts/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/fio.contracts/contracts/fio.request.obt/fio.request.obt.cpp
@@ -85,8 +85,8 @@ namespace fioio {
                         frc.payee_fio_addr = frt->payee_fio_addr;
                         frc.payee_key = frt->payee_key;
                         frc.payer_key = frt->payer_key;
-                        frc.payer_key_hex = string_to_uint128_hash(frt->payee_key.c_str());
-                        frc.payee_key_hex = string_to_uint128_hash(frt->payer_key.c_str());
+                        frc.payer_key_hex = string_to_uint128_hash(frt->payer_key.c_str());
+                        frc.payee_key_hex = string_to_uint128_hash(frt->payee_key.c_str());
 
                         wasSuccessful = true;
                     });
@@ -128,8 +128,8 @@ namespace fioio {
                         frc.payee_fio_addr = frt->payee_fio_addr;
                         frc.payee_key = frt->payee_key;
                         frc.payer_key = frt->payer_key;
-                        frc.payer_key_hex = string_to_uint128_hash(frt->payee_key.c_str());
-                        frc.payee_key_hex = string_to_uint128_hash(frt->payer_key.c_str());
+                        frc.payer_key_hex = string_to_uint128_hash(frt->payer_key.c_str());
+                        frc.payee_key_hex = string_to_uint128_hash(frt->payee_key.c_str());
 
                         wasSuccessful = true;
                     });

--- a/fio.contracts/contracts/fio.request.obt/fio.request.obt.hpp
+++ b/fio.contracts/contracts/fio.request.obt/fio.request.obt.hpp
@@ -51,13 +51,13 @@ namespace fioio {
         uint64_t primary_key() const { return fio_request_id; }
         uint128_t by_receiver() const { return payer_fio_address; }
         uint128_t by_originator() const { return payee_fio_address; }
-        uint128_t by_payerwtime() const { return payer_fio_address_with_time;}
-        uint128_t by_payeewtime() const { return payee_fio_address_with_time;}
+        uint128_t by_payerwtime() const { return payer_fio_address_with_time; }
+        uint128_t by_payeewtime() const { return payee_fio_address_with_time; }
 
         EOSLIB_SERIALIZE(fioreqctxt,
         (fio_request_id)(payer_fio_address)(payee_fio_address)(payer_fio_address_hex_str)(payee_fio_address_hex_str)
                 (payer_fio_address_with_time)(payee_fio_address_with_time)
-        (content)(time_stamp)(payer_fio_addr)(payee_fio_addr)(payer_key)(payee_key)
+                (content)(time_stamp)(payer_fio_addr)(payee_fio_addr)(payer_key)(payee_key)
         )
     };
 
@@ -69,6 +69,49 @@ namespace fioio {
     indexed_by<"bypayeewtime"_n, const_mem_fun<fioreqctxt, uint128_t, &fioreqctxt::by_payeewtime>
     >>
     fiorequest_contexts_table;
+
+    // TEMP MIGRATION TABLE
+    struct [[eosio::action]] fioreqctxt2 {
+        uint64_t fio_request_id;
+        uint128_t payer_fio_addr_hex;
+        uint128_t payee_fio_addr_hex;
+        string content;  //this content is a encrypted blob containing the details of the request.
+        uint64_t time_stamp;
+        string payer_fio_addr;
+        string payee_fio_addr;
+        string payer_key = nullptr;
+        string payee_key = nullptr;
+        uint128_t payer_key_hex;
+        uint128_t payee_key_hex;
+
+        //Future use
+        string futureuse_string1 = nullptr;
+        string futureuse_string2 = nullptr;
+        uint64_t futureuse_uint64 = 0;
+        uint128_t futureuse_uint128 = 0;
+
+        uint64_t primary_key() const { return fio_request_id; }
+        uint128_t by_receiver() const { return payer_fio_addr_hex; }
+        uint128_t by_originator() const { return payee_fio_addr_hex; }
+        uint128_t by_payerkey() const { return payer_key_hex; }
+        uint128_t by_payeekey() const { return payee_key_hex; }
+        uint128_t by_stduint128() const { return futureuse_uint128; }
+
+        EOSLIB_SERIALIZE(fioreqctxt2,
+        (fio_request_id)(payer_fio_addr_hex)(payee_fio_addr_hex)(content)(time_stamp)
+                (payer_fio_addr)(payee_fio_addr)(payer_key)(payee_key)(payer_key_hex)(payee_key_hex)(futureuse_string1)
+                (futureuse_string2)(futureuse_uint64)(futureuse_uint128)
+        )
+    };
+
+    typedef multi_index<"fioreqctxts2"_n, fioreqctxt2,
+            indexed_by<"byreceiver"_n, const_mem_fun < fioreqctxt2, uint128_t, &fioreqctxt2::by_receiver>>,
+    indexed_by<"byoriginator"_n, const_mem_fun<fioreqctxt2, uint128_t, &fioreqctxt2::by_originator>>,
+    indexed_by<"bypayerkey"_n, const_mem_fun<fioreqctxt2, uint128_t, &fioreqctxt2::by_payerkey>>,
+    indexed_by<"bypayeekey"_n, const_mem_fun<fioreqctxt2, uint128_t, &fioreqctxt2::by_payeekey>>,
+    indexed_by<"bystduint"_n, const_mem_fun<fioreqctxt2, uint128_t, &fioreqctxt2::by_stduint128>
+    >>
+    fiorequest2_contexts_table;
 
     //this struct holds records relating to the items sent via record obt, we call them recordobt_info items.
     struct [[eosio::action]] recordobt_info {
@@ -92,11 +135,10 @@ namespace fioio {
         uint128_t by_payeewtime() const { return payee_fio_address_with_time; }
         uint128_t by_payerwtime() const { return payer_fio_address_with_time; }
 
-
         EOSLIB_SERIALIZE(recordobt_info,
         (id)(payer_fio_address)(payee_fio_address)(payer_fio_address_hex_str)(payee_fio_address_hex_str)
-        (payer_fio_address_with_time)(payee_fio_address_with_time)
-        (content)(time_stamp)(payer_fio_addr)(payee_fio_addr)(payer_key)(payee_key)
+                (payer_fio_address_with_time)(payee_fio_address_with_time)
+                (content)(time_stamp)(payer_fio_addr)(payee_fio_addr)(payer_key)(payee_key)
         )
     };
 
@@ -107,6 +149,49 @@ namespace fioio {
     indexed_by<"bypayeewtime"_n, const_mem_fun<recordobt_info, uint128_t, &recordobt_info::by_payeewtime>
     >>
     recordobt_table;
+
+    // TEMP MIGRATION TABLE
+    struct [[eosio::action]] recobt_info2 {
+        uint64_t id;
+        uint128_t payer_fio_addr_hex;
+        uint128_t payee_fio_addr_hex;
+        string content;  //this content is a encrypted blob containing the details of the request.
+        uint64_t time_stamp;
+        string payer_fio_addr;
+        string payee_fio_addr;
+        string payer_key = nullptr;
+        string payee_key = nullptr;
+        uint128_t payer_key_hex;
+        uint128_t payee_key_hex;
+
+        //Future use
+        string futureuse_string1 = nullptr;
+        string futureuse_string2 = nullptr;
+        uint64_t futureuse_uint64 = 0;
+        uint128_t futureuse_uint128 = 0;
+
+        uint64_t primary_key() const { return id; }
+        uint128_t by_receiver() const { return payer_fio_addr_hex; }
+        uint128_t by_originator() const { return payee_fio_addr_hex; }
+        uint128_t by_payerkey() const { return payer_key_hex; }
+        uint128_t by_payeekey() const { return payee_key_hex; }
+        uint128_t by_stduint128() const { return futureuse_uint128; }
+
+        EOSLIB_SERIALIZE(recobt_info2,
+        (id)(payer_fio_addr_hex)(payee_fio_addr_hex)(content)(time_stamp)
+                (payer_fio_addr)(payee_fio_addr)(payer_key)(payee_key)(payer_key_hex)(payee_key_hex)(futureuse_string1)
+                (futureuse_string2)(futureuse_uint64)(futureuse_uint128)
+        )
+    };
+
+    typedef multi_index<"recordobts2"_n, recobt_info2,
+            indexed_by<"byreceiver"_n, const_mem_fun < recobt_info2, uint128_t, &recobt_info2::by_receiver>>,
+    indexed_by<"byoriginator"_n, const_mem_fun<recobt_info2, uint128_t, &recobt_info2::by_originator>>,
+    indexed_by<"bypayerkey"_n, const_mem_fun<recobt_info2, uint128_t, &recobt_info2::by_payerkey>>,
+    indexed_by<"bypayeekey"_n, const_mem_fun<recobt_info2, uint128_t, &recobt_info2::by_payeekey>>,
+    indexed_by<"bystduint"_n, const_mem_fun<recobt_info2, uint128_t, &recobt_info2::by_stduint128>
+    >>
+    recobt2_table;
 
     // The FIO request status table references FIO requests that have had funds sent, or have been rejected.
     // the table provides a means to find the status of a request.

--- a/libraries/chain/include/eosio/chain/fioio/actionmapping.hpp
+++ b/libraries/chain/include/eosio/chain/fioio/actionmapping.hpp
@@ -48,7 +48,7 @@ namespace fioio {
             action == "transfer" || action == "mintfio")
           return "fio.token";
         //fio.request.obt actions
-        if (action == "recordobt" || action == "rejectfndreq" || action == "cancelfndreq"  || action == "newfundsreq")
+        if (action == "recordobt" || action == "migreqtxt" || action == "migobttxt" || action == "rejectfndreq" || action == "cancelfndreq"  || action == "newfundsreq")
           return "fio.reqobt";
 
         //fio.tpid actions


### PR DESCRIPTION
The current table structure for FIO requests does not support public key searching. This results in improper requests returned after transferring an FIO address. To achieve this, a table migration is necessary and prior data needs to be moved into a temporary index table.

Tables being migrated:
- fioreqctxt ( fioreqctxts )
- recordobt_info ( recordobts )

The major index table changes are the following:
- Removal of payee and payer time
- Removal of duplicate hex values.
- Add support for key index searching

**Currently, actions are enabled for testing.** 


