### PR TITLE
Step 2: Migrate Request and OBT tables back to original index tables.

### DIFF
--- a/fio.contracts/contracts/fio.request.obt/fio.request.obt.abi
+++ b/fio.contracts/contracts/fio.request.obt/fio.request.obt.abi
@@ -3,50 +3,56 @@
   "version": "eosio::abi/1.0",
   "types": [],
   "structs": [{
-      "name": "fioreqctxt",
-      "base": "",
-      "fields": [{
-          "name": "fio_request_id",
-          "type": "uint64"
-        },{
-          "name": "payer_fio_address",
-          "type": "uint128"
-        },{
-          "name": "payee_fio_address",
-          "type": "uint128"
-        },{
-          "name": "payer_fio_address_hex_str",
-          "type": "string"
-        },{
-          "name": "payee_fio_address_hex_str",
-          "type": "string"
-        },{
-          "name": "payer_fio_address_with_time",
-          "type": "uint128"
-        },{
-          "name": "payee_fio_address_with_time",
-          "type": "uint128"
-        },{
-          "name": "content",
-          "type": "string"
-        },{
-          "name": "time_stamp",
-          "type": "uint64"
-        },{
-          "name": "payer_fio_addr",
-          "type": "string"
-        },{
-          "name": "payee_fio_addr",
-          "type": "string"
-         },{
-          "name": "payer_key",
-          "type": "string"
-         },{
-          "name": "payee_key",
-          "type": "string"
-         }
-      ]
-    },{
+                                          "name": "fioreqctxt1",
+                                          "base": "",
+                                          "fields": [{
+                                              "name": "fio_request_id",
+                                              "type": "uint64"
+                                            },{
+                                              "name": "payer_fio_addr_hex",
+                                              "type": "uint128"
+                                            },{
+                                              "name": "payee_fio_addr_hex",
+                                              "type": "uint128"
+                                            },{
+                                              "name": "content",
+                                              "type": "string"
+                                            },{
+                                              "name": "time_stamp",
+                                              "type": "uint64"
+                                            },{
+                                              "name": "payer_fio_addr",
+                                              "type": "string"
+                                            },{
+                                              "name": "payee_fio_addr",
+                                              "type": "string"
+                                             },{
+                                              "name": "payer_key",
+                                              "type": "string"
+                                             },{
+                                              "name": "payee_key",
+                                              "type": "string"
+                                             },{
+                                              "name": "payer_key_hex",
+                                              "type": "uint128"
+                                            },{
+                                              "name": "payee_key_hex",
+                                              "type": "uint128"
+                                            },{
+                                              "name": "futureuse_string1",
+                                              "type": "string"
+                                             },{
+                                              "name": "futureuse_string2",
+                                              "type": "string"
+                                             },{
+                                              "name": "futureuse_uint64",
+                                              "type": "uint64"
+                                            },{
+                                              "name": "futureuse_uint128",
+                                              "type": "uint128"
+                                            }
+                                          ]
+                                        },{
                             "name": "fioreqctxt2",
                             "base": "",
                             "fields": [{
@@ -97,50 +103,56 @@
                               }
                             ]
                           },{
-            "name": "recordobt_info",
-            "base": "",
-            "fields": [{
-                "name": "id",
-                "type": "uint64"
-              },{
-                "name": "payer_fio_address",
-                "type": "uint128"
-              },{
-                "name": "payee_fio_address",
-                "type": "uint128"
-              },{
-                "name": "payer_fio_address_hex_str",
-                "type": "string"
-              },{
-                "name": "payee_fio_address_hex_str",
-                "type": "string"
-              },{
-                "name": "payer_fio_address_with_time",
-                "type": "uint128"
-              },{
-                "name": "payee_fio_address_with_time",
-                "type": "uint128"
-              },{
-                "name": "content",
-                "type": "string"
-              },{
-                "name": "time_stamp",
-                "type": "uint64"
-              },{
-                "name": "payer_fio_addr",
-                "type": "string"
-              },{
-                "name": "payee_fio_addr",
-                "type": "string"
-               },{
-                "name": "payer_key",
-                "type": "string"
-               },{
-                "name": "payee_key",
-                "type": "string"
-               }
-            ]
-          },{
+                                        "name": "recordobt_info",
+                                        "base": "",
+                                        "fields": [{
+                                            "name": "id",
+                                            "type": "uint64"
+                                          },{
+                                            "name": "payer_fio_addr_hex",
+                                            "type": "uint128"
+                                          },{
+                                            "name": "payee_fio_addr_hex",
+                                            "type": "uint128"
+                                          },{
+                                            "name": "content",
+                                            "type": "string"
+                                          },{
+                                            "name": "time_stamp",
+                                            "type": "uint64"
+                                          },{
+                                            "name": "payer_fio_addr",
+                                            "type": "string"
+                                          },{
+                                            "name": "payee_fio_addr",
+                                            "type": "string"
+                                           },{
+                                            "name": "payer_key",
+                                            "type": "string"
+                                           },{
+                                            "name": "payee_key",
+                                            "type": "string"
+                                           },{
+                                            "name": "payer_key_hex",
+                                            "type": "uint128"
+                                          },{
+                                            "name": "payee_key_hex",
+                                            "type": "uint128"
+                                          },{
+                                            "name": "futureuse_string1",
+                                            "type": "string"
+                                           },{
+                                            "name": "futureuse_string2",
+                                            "type": "string"
+                                           },{
+                                            "name": "futureuse_uint64",
+                                            "type": "uint64"
+                                          },{
+                                            "name": "futureuse_uint128",
+                                            "type": "uint128"
+                                          }
+                                        ]
+                                      },{
             "name": "recobt_info2",
             "base": "",
             "fields": [{

--- a/fio.contracts/contracts/fio.request.obt/fio.request.obt.abi
+++ b/fio.contracts/contracts/fio.request.obt/fio.request.obt.abi
@@ -3,7 +3,7 @@
   "version": "eosio::abi/1.0",
   "types": [],
   "structs": [{
-                                          "name": "fioreqctxt1",
+                                          "name": "fioreqctxt",
                                           "base": "",
                                           "fields": [{
                                               "name": "fio_request_id",

--- a/fio.contracts/contracts/fio.request.obt/fio.request.obt.abi
+++ b/fio.contracts/contracts/fio.request.obt/fio.request.obt.abi
@@ -222,15 +222,26 @@
           "type": "uint64"
         }
       ]
-    },,{
-            "name": "fioreqsts",
+    },{
+                 "name": "ledgerItems",
+                 "base": "",
+                 "fields": [{
+                     "name": "fio_request_ids",
+                     "type": "uint64[]"
+                   },{
+                     "name": "recordobt_ids",
+                     "type": "uint64[]"
+                   }
+                 ]
+               },{
+            "name": "reqledger",
             "base": "",
             "fields": [{
                 "name": "account",
                 "type": "uint64"
               },{
                 "name": "transactions",
-                "type": "ledgerItems[]"
+                "type": "ledgerItems"
               }
             ]
           },{

--- a/fio.contracts/contracts/fio.request.obt/fio.request.obt.abi
+++ b/fio.contracts/contracts/fio.request.obt/fio.request.obt.abi
@@ -222,7 +222,18 @@
           "type": "uint64"
         }
       ]
-    },{
+    },,{
+            "name": "fioreqsts",
+            "base": "",
+            "fields": [{
+                "name": "account",
+                "type": "uint64"
+              },{
+                "name": "transactions",
+                "type": "ledgerItems[]"
+              }
+            ]
+          },{
                          "name": "migreqtxt",
                              "base": "",
                              "fields": [{
@@ -405,7 +416,17 @@
         "uint64"
       ],
       "type": "fioreqsts"
-    }
+    },{
+           "name": "reqledgers",
+           "index_type": "i64",
+           "key_names": [
+             "account"
+           ],
+           "key_types": [
+             "uint64"
+           ],
+           "type": "reqledger"
+         }
   ],
   "ricardian_clauses": [],
   "error_messages": [],

--- a/fio.contracts/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/fio.contracts/contracts/fio.request.obt/fio.request.obt.cpp
@@ -70,30 +70,30 @@ namespace fioio {
                            "Actor not active producer", ErrorNoFioAddressProducer);
 
             uint16_t count = 0;
-            auto frt = recordObtTable.begin();
+            auto frt = recordObtTable2.begin();
 
-            while(count <= amount && frt != recordObtTable.end() ) {
+            while(count <= amount && frt != recordObtTable2.end() ) {
                 bool wasSuccessful = false;
-                for (frt = recordObtTable.begin(); frt != recordObtTable.end(); ++frt) {
-                    recordObtTable2.emplace(executor, [&](struct recobt_info2 &frc) {
+                for (frt = recordObtTable2.begin(); frt != recordObtTable2.end(); ++frt) {
+                    recordObtTable.emplace(executor, [&](struct recordobt_info &frc) {
                         frc.id = frt->id;
-                        frc.payer_fio_addr_hex = frt->payer_fio_address;
-                        frc.payee_fio_addr_hex = frt->payee_fio_address;
+                        frc.payer_fio_addr_hex = frt->payer_fio_addr_hex;
+                        frc.payee_fio_addr_hex = frt->payee_fio_addr_hex;
                         frc.content = frt->content;
                         frc.time_stamp = frt->time_stamp;
                         frc.payer_fio_addr = frt->payer_fio_addr;
                         frc.payee_fio_addr = frt->payee_fio_addr;
                         frc.payee_key = frt->payee_key;
                         frc.payer_key = frt->payer_key;
-                        frc.payer_key_hex = string_to_uint128_hash(frt->payer_key.c_str());
-                        frc.payee_key_hex = string_to_uint128_hash(frt->payee_key.c_str());
+                        frc.payer_key_hex = frt->payer_key_hex;
+                        frc.payee_key_hex = frt->payee_key_hex;
 
                         wasSuccessful = true;
                     });
                     if(wasSuccessful){ break; }
                 }
-                if(wasSuccessful && frt != recordObtTable.end()){
-                    recordObtTable.erase(frt); //  Wish deleting the iterator in the forloop was possible.
+                if(wasSuccessful && frt != recordObtTable2.end()){
+                    recordObtTable2.erase(frt); //  Wish deleting the iterator in the forloop was possible.
                     count++;
                 }
             }
@@ -113,30 +113,30 @@ namespace fioio {
                            "Actor not active producer", ErrorNoFioAddressProducer);
 
             uint16_t count = 0;
-            auto frt = fiorequestContextsTable.begin();
+            auto frt = fiorequestContextsTable2.begin();
 
-            while(count <= amount && frt != fiorequestContextsTable.end() ) {
+            while(count <= amount && frt != fiorequestContextsTable2.end() ) {
                 bool wasSuccessful = false;
-                for (frt = fiorequestContextsTable.begin(); frt != fiorequestContextsTable.end(); ++frt) {
-                    fiorequestContextsTable2.emplace(executor, [&](struct fioreqctxt2 &frc) {
+                for (frt = fiorequestContextsTable2.begin(); frt != fiorequestContextsTable2.end(); ++frt) {
+                    fiorequestContextsTable.emplace(executor, [&](struct fioreqctxt &frc) {
                         frc.fio_request_id = frt->fio_request_id;
-                        frc.payer_fio_addr_hex = frt->payer_fio_address;
-                        frc.payee_fio_addr_hex = frt->payee_fio_address;
+                        frc.payer_fio_addr_hex = frt->payer_fio_addr_hex;
+                        frc.payee_fio_addr_hex = frt->payee_fio_addr_hex;
                         frc.content = frt->content;
                         frc.time_stamp = frt->time_stamp;
                         frc.payer_fio_addr = frt->payer_fio_addr;
                         frc.payee_fio_addr = frt->payee_fio_addr;
                         frc.payee_key = frt->payee_key;
                         frc.payer_key = frt->payer_key;
-                        frc.payer_key_hex = string_to_uint128_hash(frt->payer_key.c_str());
-                        frc.payee_key_hex = string_to_uint128_hash(frt->payee_key.c_str());
+                        frc.payer_key_hex = frt->payer_key_hex;
+                        frc.payee_key_hex = frt->payee_key_hex;
 
                         wasSuccessful = true;
                     });
                     if(wasSuccessful){ break; }
                 }
-                if(wasSuccessful && frt != fiorequestContextsTable.end()){
-                    fiorequestContextsTable.erase(frt); //  Wish deleting the iterator in the forloop was possible.
+                if(wasSuccessful && frt != fiorequestContextsTable2.end()){
+                    fiorequestContextsTable2.erase(frt); //  Wish deleting the iterator in the forloop was possible.
                     count++;
                 }
             }
@@ -165,7 +165,7 @@ namespace fioio {
                 const string &actor,
                 const string &tpid) {
 
-            //check(false, "Table migration in progress. All requests and OBT actions paused.");
+            check(false, "Table migration in progress. All requests and OBT actions paused.");
             name aactor = name(actor.c_str());
             require_auth(aactor);
             fio_400_assert(validateTPIDFormat(tpid), "tpid", tpid,
@@ -304,27 +304,21 @@ namespace fioio {
                 const uint64_t currentTime = now();
                 const uint128_t toHash = string_to_uint128_hash(payee_fio_address.c_str());
                 const uint128_t fromHash = string_to_uint128_hash(payer_fio_address.c_str());
-                const string toHashStr = "0x" + to_hex((char *) &toHash, sizeof(toHash));
-                const string fromHashStr = "0x" + to_hex((char *) &fromHash, sizeof(fromHash));
-                const string payerwtimestr = payer_fio_address + to_string(currentTime);
-                const string payeewtimestr = payee_fio_address + to_string(currentTime);
-                const uint128_t payeewtime = string_to_uint128_hash(payeewtimestr.c_str());
-                const uint128_t payerwtime = string_to_uint128_hash(payerwtimestr.c_str());
+                const uint128_t payeeKeyHash = string_to_uint128_hash(payee_key.c_str());
+                const uint128_t payerKeyHash = string_to_uint128_hash(payer_key.c_str());
 
                 recordObtTable.emplace(aactor, [&](struct recordobt_info &obtinf) {
                     obtinf.id = id;
-                    obtinf.payer_fio_address = fromHash;
-                    obtinf.payee_fio_address = toHash;
-                    obtinf.payer_fio_address_hex_str = fromHashStr;
-                    obtinf.payee_fio_address_hex_str = toHashStr;
-                    obtinf.payer_fio_address_with_time = payerwtime;
-                    obtinf.payee_fio_address_with_time = payeewtime;
+                    obtinf.payer_fio_addr_hex = fromHash;
+                    obtinf.payee_fio_addr_hex = toHash;
                     obtinf.content = content;
                     obtinf.time_stamp = currentTime;
                     obtinf.payer_fio_addr = payer_fio_address;
                     obtinf.payee_fio_addr = payee_fio_address;
                     obtinf.payee_key = payee_key;
                     obtinf.payer_key = payer_key;
+                    obtinf.payee_key_hex = payeeKeyHash;
+                    obtinf.payer_key_hex = payerKeyHash;
                 });
             }
 
@@ -365,7 +359,7 @@ namespace fioio {
                 const string &actor,
                 const string &tpid) {
 
-            //check(false, "Table migration in progress. All requests and OBT actions paused.");
+            check(false, "Table migration in progress. All requests and OBT actions paused.");
             const name aActor = name(actor.c_str());
             require_auth(aActor);
             fio_400_assert(validateTPIDFormat(tpid), "tpid", tpid,
@@ -483,27 +477,21 @@ namespace fioio {
             const uint64_t currentTime = now();
             const uint128_t toHash = string_to_uint128_hash(payee_fio_address.c_str());
             const uint128_t fromHash = string_to_uint128_hash(payer_fio_address.c_str());
-            const string payerwtimestr = payer_fio_address + to_string(currentTime);
-            const string payeewtimestr = payee_fio_address + to_string(currentTime);
-            const uint128_t payeewtime = string_to_uint128_hash(payeewtimestr.c_str());
-            const uint128_t payerwtime = string_to_uint128_hash(payerwtimestr.c_str());
-            const string toHashStr = "0x" + to_hex((char *) &toHash, sizeof(toHash));
-            const string fromHashStr = "0x" + to_hex((char *) &fromHash, sizeof(fromHash));
+            const uint128_t payeeKeyHash = string_to_uint128_hash(payee_key.c_str());
+            const uint128_t payerKeyHash = string_to_uint128_hash(payer_key.c_str());
 
             fiorequestContextsTable.emplace(aActor, [&](struct fioreqctxt &frc) {
                 frc.fio_request_id = id;
-                frc.payer_fio_address = fromHash;
-                frc.payee_fio_address = toHash;
-                frc.payer_fio_address_hex_str = fromHashStr;
-                frc.payee_fio_address_hex_str = toHashStr;
-                frc.payer_fio_address_with_time= payerwtime;
-                frc.payee_fio_address_with_time=payeewtime;
+                frc.payer_fio_addr_hex = fromHash;
+                frc.payee_fio_addr_hex = toHash;
                 frc.content = content;
                 frc.time_stamp = currentTime;
                 frc.payer_fio_addr = payer_fio_address;
                 frc.payee_fio_addr = payee_fio_address;
                 frc.payee_key = payee_key;
                 frc.payer_key = payer_key;
+                frc.payee_key_hex = payeeKeyHash;
+                frc.payer_key_hex = payerKeyHash;
             });
 
            const string response_string = string("{\"fio_request_id\":") + to_string(id) + string(",\"status\":\"requested\"") +
@@ -542,7 +530,7 @@ namespace fioio {
                 const string &actor,
                 const string &tpid) {
 
-            //check(false, "Table migration in progress. All requests and OBT actions paused.");
+            check(false, "Table migration in progress. All requests and OBT actions paused.");
             const name aactor = name(actor.c_str());
             require_auth(aactor);
             fio_400_assert(validateTPIDFormat(tpid), "tpid", tpid,
@@ -563,7 +551,7 @@ namespace fioio {
             fio_400_assert(fioreqctx_iter != fiorequestContextsTable.end(), "fio_request_id", fio_request_id,
                            "No such FIO Request", ErrorRequestContextNotFound);
 
-            const uint128_t payer128FioAddHashed = fioreqctx_iter->payer_fio_address;
+            const uint128_t payer128FioAddHashed = fioreqctx_iter->payer_fio_addr_hex;
             const uint32_t present_time = now();
 
             auto namesbyname = fionames.get_index<"byname"_n>();
@@ -681,7 +669,7 @@ namespace fioio {
             const string &actor,
             const string &tpid) {
 
-        //check(false, "Table migration in progress. All requests and OBT actions paused.");
+        check(false, "Table migration in progress. All requests and OBT actions paused.");
         const name aactor = name(actor.c_str());
         require_auth(aactor);
         fio_400_assert(validateTPIDFormat(tpid), "tpid", tpid,
@@ -702,7 +690,7 @@ namespace fioio {
         fio_400_assert(fioreqctx_iter != fiorequestContextsTable.end(), "fio_request_id", fio_request_id,
                        "No such FIO Request", ErrorRequestContextNotFound);
 
-        const uint128_t payee128FioAddHashed = fioreqctx_iter->payee_fio_address;
+        const uint128_t payee128FioAddHashed = fioreqctx_iter->payee_fio_addr_hex;
         const uint32_t present_time = now();
 
         //look for other statuses for this request.

--- a/fio.contracts/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/fio.contracts/contracts/fio.request.obt/fio.request.obt.cpp
@@ -159,22 +159,22 @@ namespace fioio {
                     if (ledg_iter == ledgerTable.end()) {
                         ledgerTable.emplace(executor,[&](struct reqledger &req) {
                             req.account = name(payer_acct.c_str()).value;
-                            req.transactions.recordobt_ids.insert(req.transactions.recordobt_ids.begin(), frt->fio_request_id);
+                            req.transactions.recordobt_ids.insert(req.transactions.fio_request_ids.begin(), frt->fio_request_id);
                         });
                     } else {
                         ledgerTable.modify(ledg_iter, _self, [&](struct reqledger &req) {
-                            req.transactions.recordobt_ids.insert(req.transactions.recordobt_ids.begin(), frt->fio_request_id);
+                            req.transactions.recordobt_ids.insert(req.transactions.fio_request_ids.begin(), frt->fio_request_id);
                         });
                     }
 
                     if (ledg_iter2 == ledgerTable.end()) {
                         ledgerTable.emplace(executor,[&](struct reqledger &req) {
                             req.account = name(payee_acct.c_str()).value;
-                            req.transactions.recordobt_ids.insert(req.transactions.recordobt_ids.begin(), frt->fio_request_id);
+                            req.transactions.recordobt_ids.insert(req.transactions.fio_request_ids.begin(), frt->fio_request_id);
                         });
                     } else {
                         ledgerTable.modify(ledg_iter2, _self, [&](struct reqledger &req) {
-                            req.transactions.recordobt_ids.insert(req.transactions.recordobt_ids.begin(), frt->fio_request_id);
+                            req.transactions.recordobt_ids.insert(req.transactions.fio_request_ids.begin(), frt->fio_request_id);
                         });
                     }
 

--- a/fio.contracts/contracts/fio.request.obt/fio.request.obt.hpp
+++ b/fio.contracts/contracts/fio.request.obt/fio.request.obt.hpp
@@ -35,38 +35,43 @@ namespace fioio {
     // @abi table fioreqctxts i64
     struct [[eosio::action]] fioreqctxt {
         uint64_t fio_request_id;
-        uint128_t payer_fio_address;
-        uint128_t payee_fio_address;
-        string payer_fio_address_hex_str;
-        string payee_fio_address_hex_str;
-        uint128_t payer_fio_address_with_time;
-        uint128_t payee_fio_address_with_time;
+        uint128_t payer_fio_addr_hex;
+        uint128_t payee_fio_addr_hex;
         string content;  //this content is a encrypted blob containing the details of the request.
         uint64_t time_stamp;
         string payer_fio_addr;
         string payee_fio_addr;
         string payer_key = nullptr;
         string payee_key = nullptr;
+        uint128_t payer_key_hex;
+        uint128_t payee_key_hex;
+
+        //Future use
+        string futureuse_string1 = nullptr;
+        string futureuse_string2 = nullptr;
+        uint64_t futureuse_uint64 = 0;
+        uint128_t futureuse_uint128 = 0;
 
         uint64_t primary_key() const { return fio_request_id; }
-        uint128_t by_receiver() const { return payer_fio_address; }
-        uint128_t by_originator() const { return payee_fio_address; }
-        uint128_t by_payerwtime() const { return payer_fio_address_with_time; }
-        uint128_t by_payeewtime() const { return payee_fio_address_with_time; }
+        uint128_t by_receiver() const { return payer_fio_addr_hex; }
+        uint128_t by_originator() const { return payee_fio_addr_hex; }
+        uint128_t by_payerkey() const { return payer_key_hex; }
+        uint128_t by_payeekey() const { return payee_key_hex; }
+        uint128_t by_stduint128() const { return futureuse_uint128; }
 
         EOSLIB_SERIALIZE(fioreqctxt,
-        (fio_request_id)(payer_fio_address)(payee_fio_address)(payer_fio_address_hex_str)(payee_fio_address_hex_str)
-                (payer_fio_address_with_time)(payee_fio_address_with_time)
-                (content)(time_stamp)(payer_fio_addr)(payee_fio_addr)(payer_key)(payee_key)
+        (fio_request_id)(payer_fio_addr_hex)(payee_fio_addr_hex)(content)(time_stamp)
+                (payer_fio_addr)(payee_fio_addr)(payer_key)(payee_key)(payer_key_hex)(payee_key_hex)(futureuse_string1)
+                (futureuse_string2)(futureuse_uint64)(futureuse_uint128)
         )
     };
-
 
     typedef multi_index<"fioreqctxts"_n, fioreqctxt,
             indexed_by<"byreceiver"_n, const_mem_fun < fioreqctxt, uint128_t, &fioreqctxt::by_receiver>>,
     indexed_by<"byoriginator"_n, const_mem_fun<fioreqctxt, uint128_t, &fioreqctxt::by_originator>>,
-    indexed_by<"bypayerwtime"_n, const_mem_fun<fioreqctxt, uint128_t, &fioreqctxt::by_payerwtime>>,
-    indexed_by<"bypayeewtime"_n, const_mem_fun<fioreqctxt, uint128_t, &fioreqctxt::by_payeewtime>
+    indexed_by<"bypayerkey"_n, const_mem_fun<fioreqctxt, uint128_t, &fioreqctxt::by_payerkey>>,
+    indexed_by<"bypayeekey"_n, const_mem_fun<fioreqctxt, uint128_t, &fioreqctxt::by_payeekey>>,
+    indexed_by<"bystduint"_n, const_mem_fun<fioreqctxt, uint128_t, &fioreqctxt::by_stduint128>
     >>
     fiorequest_contexts_table;
 
@@ -116,37 +121,43 @@ namespace fioio {
     //this struct holds records relating to the items sent via record obt, we call them recordobt_info items.
     struct [[eosio::action]] recordobt_info {
         uint64_t id;
-        uint128_t payer_fio_address;
-        uint128_t payee_fio_address;
-        string payer_fio_address_hex_str;
-        string payee_fio_address_hex_str;
-        uint128_t payer_fio_address_with_time;
-        uint128_t payee_fio_address_with_time;
+        uint128_t payer_fio_addr_hex;
+        uint128_t payee_fio_addr_hex;
         string content;  //this content is a encrypted blob containing the details of the request.
         uint64_t time_stamp;
         string payer_fio_addr;
         string payee_fio_addr;
         string payer_key = nullptr;
         string payee_key = nullptr;
+        uint128_t payer_key_hex;
+        uint128_t payee_key_hex;
+
+        //Future use
+        string futureuse_string1 = nullptr;
+        string futureuse_string2 = nullptr;
+        uint64_t futureuse_uint64 = 0;
+        uint128_t futureuse_uint128 = 0;
 
         uint64_t primary_key() const { return id; }
-        uint128_t by_payee() const { return payee_fio_address; }
-        uint128_t by_payer() const { return payer_fio_address; }
-        uint128_t by_payeewtime() const { return payee_fio_address_with_time; }
-        uint128_t by_payerwtime() const { return payer_fio_address_with_time; }
+        uint128_t by_receiver() const { return payer_fio_addr_hex; }
+        uint128_t by_originator() const { return payee_fio_addr_hex; }
+        uint128_t by_payerkey() const { return payer_key_hex; }
+        uint128_t by_payeekey() const { return payee_key_hex; }
+        uint128_t by_stduint128() const { return futureuse_uint128; }
 
         EOSLIB_SERIALIZE(recordobt_info,
-        (id)(payer_fio_address)(payee_fio_address)(payer_fio_address_hex_str)(payee_fio_address_hex_str)
-                (payer_fio_address_with_time)(payee_fio_address_with_time)
-                (content)(time_stamp)(payer_fio_addr)(payee_fio_addr)(payer_key)(payee_key)
+        (id)(payer_fio_addr_hex)(payee_fio_addr_hex)(content)(time_stamp)
+                (payer_fio_addr)(payee_fio_addr)(payer_key)(payee_key)(payer_key_hex)(payee_key_hex)(futureuse_string1)
+                (futureuse_string2)(futureuse_uint64)(futureuse_uint128)
         )
     };
 
     typedef multi_index<"recordobts"_n, recordobt_info,
-            indexed_by<"bypayee"_n, const_mem_fun < recordobt_info, uint128_t, &recordobt_info::by_payee>>,
-    indexed_by<"bypayer"_n, const_mem_fun<recordobt_info, uint128_t, &recordobt_info::by_payer>>,
-    indexed_by<"bypayerwtime"_n, const_mem_fun<recordobt_info, uint128_t, &recordobt_info::by_payerwtime>>,
-    indexed_by<"bypayeewtime"_n, const_mem_fun<recordobt_info, uint128_t, &recordobt_info::by_payeewtime>
+            indexed_by<"byreceiver"_n, const_mem_fun < recordobt_info, uint128_t, &recordobt_info::by_receiver>>,
+    indexed_by<"byoriginator"_n, const_mem_fun<recordobt_info, uint128_t, &recordobt_info::by_originator>>,
+    indexed_by<"bypayerkey"_n, const_mem_fun<recordobt_info, uint128_t, &recordobt_info::by_payerkey>>,
+    indexed_by<"bypayeekey"_n, const_mem_fun<recordobt_info, uint128_t, &recordobt_info::by_payeekey>>,
+    indexed_by<"bystduint"_n, const_mem_fun<recordobt_info, uint128_t, &recordobt_info::by_stduint128>
     >>
     recordobt_table;
 

--- a/fio.contracts/contracts/fio.request.obt/fio.request.obt.hpp
+++ b/fio.contracts/contracts/fio.request.obt/fio.request.obt.hpp
@@ -30,6 +30,11 @@ namespace fioio {
         cancelled = 3
     };
 
+    struct ledgerItems {
+        std::vector<uint64_t> fio_request_ids;
+        std::vector<uint64_t> recordobt_ids;
+    };
+
     // The request context table holds the requests for funds that have been requested, it provides
     // searching by id, payer and payee.
     // @abi table fioreqctxts i64
@@ -225,4 +230,16 @@ namespace fioio {
             indexed_by<"byfioreqid"_n, const_mem_fun < fioreqsts, uint64_t, &fioreqsts::by_fioreqid> >
     >
     fiorequest_status_table;
+
+    struct [[eosio::action]] reqledger {
+
+        uint64_t account;
+        ledgerItems transactions;
+
+        uint64_t primary_key() const { return account; }
+
+        EOSLIB_SERIALIZE(reqledger, (account)(transactions))
+    };
+
+    typedef multi_index<"reqledgers"_n, reqledger> reqledgers_table;
 }


### PR DESCRIPTION
This is the 2nd step in the migration process. Data will be returned to the edited original index tables and references for their use within actions will be fixed. During this process, actions will still be locked. 