### PR TITLE
add new endpoint for get_actor

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -107,6 +107,7 @@ namespace eosio {
                                      CHAIN_RO_CALL(get_required_keys, 200),
                                      CHAIN_RO_CALL(get_transaction_id, 200),
                                      CHAIN_RO_CALL(get_fio_balance, 200),
+                                     CHAIN_RO_CALL(fio_public_key_to_account, 200),
                                      CHAIN_RO_CALL(get_fio_names, 200),
                                      CHAIN_RO_CALL(get_fee, 200),
                                      CHAIN_RO_CALL(avail_check, 200),

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -107,7 +107,7 @@ namespace eosio {
                                      CHAIN_RO_CALL(get_required_keys, 200),
                                      CHAIN_RO_CALL(get_transaction_id, 200),
                                      CHAIN_RO_CALL(get_fio_balance, 200),
-                                     CHAIN_RO_CALL(fio_public_key_to_account, 200),
+                                     CHAIN_RO_CALL(get_actor, 200),
                                      CHAIN_RO_CALL(get_fio_names, 200),
                                      CHAIN_RO_CALL(get_fee, 200),
                                      CHAIN_RO_CALL(avail_check, 200),

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2319,6 +2319,22 @@ if( options.count(name) ) { \
             return result;
         } //get_fio_balance
 
+        read_only::fio_public_key_to_account_result read_only::fio_public_key_to_account(const read_only::fio_public_key_to_account_params &p) const {
+
+            FIO_400_ASSERT(fioio::isPubKeyValid(p.fio_public_key), "fio_public_key", p.fio_public_key.c_str(),
+                           "Invalid FIO Public Key",
+                           fioio::ErrorPubKeyValid);
+
+
+            fio_public_key_to_account_result result;
+            string account_name;
+            fioio::key_to_account(p.fio_public_key, account_name);
+            result.account = account_name;
+
+
+            return result;
+        } //fio_public_key_to_account
+
         /*** v1/chain/get_fee
         * Retrieves the fee associated with the specified fio address and blockchain endpoint
         * @param p

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2319,21 +2319,21 @@ if( options.count(name) ) { \
             return result;
         } //get_fio_balance
 
-        read_only::fio_public_key_to_account_result read_only::fio_public_key_to_account(const read_only::fio_public_key_to_account_params &p) const {
+        read_only::get_actor_result read_only::get_actor(const read_only::get_actor_params &p) const {
 
             FIO_400_ASSERT(fioio::isPubKeyValid(p.fio_public_key), "fio_public_key", p.fio_public_key.c_str(),
                            "Invalid FIO Public Key",
                            fioio::ErrorPubKeyValid);
 
 
-            fio_public_key_to_account_result result;
+            get_actor_result result;
             string account_name;
             fioio::key_to_account(p.fio_public_key, account_name);
-            result.account = account_name;
+            result.actor = account_name;
 
 
             return result;
-        } //fio_public_key_to_account
+        } //get_actor
 
         /*** v1/chain/get_fee
         * Retrieves the fee associated with the specified fio address and blockchain endpoint

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -549,15 +549,15 @@ namespace eosio {
 
             get_fio_balance_result get_fio_balance(const get_fio_balance_params &params) const;
 
-            struct fio_public_key_to_account_params {
+            struct get_actor_params {
                 fc::string fio_public_key;
             };
 
-            struct fio_public_key_to_account_result {
-                string account;
+            struct get_actor_result {
+                string actor;
             };
 
-            fio_public_key_to_account_result fio_public_key_to_account(const fio_public_key_to_account_params &params) const;
+            get_actor_result get_actor(const get_actor_params &params) const;
 
 
             void obt_data_search(uint32_t search_limit, get_obt_data_result &result, const abi_def &reqobt_abi,
@@ -1350,8 +1350,8 @@ FC_REFLECT(eosio::chain_apis::read_only::get_currency_stats_params, (code)(symbo
 FC_REFLECT(eosio::chain_apis::read_only::get_currency_stats_result, (supply)(max_supply)(issuer));
 FC_REFLECT(eosio::chain_apis::read_only::get_fio_balance_params, (fio_public_key));
 FC_REFLECT(eosio::chain_apis::read_only::get_fio_balance_result, (balance));
-FC_REFLECT(eosio::chain_apis::read_only::fio_public_key_to_account_params, (fio_public_key));
-FC_REFLECT(eosio::chain_apis::read_only::fio_public_key_to_account_result, (account));
+FC_REFLECT(eosio::chain_apis::read_only::get_actor_params, (fio_public_key));
+FC_REFLECT(eosio::chain_apis::read_only::get_actor_result, (actor));
 FC_REFLECT(eosio::chain_apis::read_only::get_producers_params, (json)(lower_bound)(limit))
 FC_REFLECT(eosio::chain_apis::read_only::get_producers_result, (producers)(total_producer_vote_weight)(more));
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -549,6 +549,17 @@ namespace eosio {
 
             get_fio_balance_result get_fio_balance(const get_fio_balance_params &params) const;
 
+            struct fio_public_key_to_account_params {
+                fc::string fio_public_key;
+            };
+
+            struct fio_public_key_to_account_result {
+                string account;
+            };
+
+            fio_public_key_to_account_result fio_public_key_to_account(const fio_public_key_to_account_params &params) const;
+
+
             void obt_data_search(uint32_t search_limit, get_obt_data_result &result, const abi_def &reqobt_abi,
                                  const get_table_rows_result &table_rows_result, uint32_t &search_results,
                                  uint32_t &search_offset, uint32_t &returnCount, bool &search_finished,
@@ -1339,6 +1350,8 @@ FC_REFLECT(eosio::chain_apis::read_only::get_currency_stats_params, (code)(symbo
 FC_REFLECT(eosio::chain_apis::read_only::get_currency_stats_result, (supply)(max_supply)(issuer));
 FC_REFLECT(eosio::chain_apis::read_only::get_fio_balance_params, (fio_public_key));
 FC_REFLECT(eosio::chain_apis::read_only::get_fio_balance_result, (balance));
+FC_REFLECT(eosio::chain_apis::read_only::fio_public_key_to_account_params, (fio_public_key));
+FC_REFLECT(eosio::chain_apis::read_only::fio_public_key_to_account_result, (account));
 FC_REFLECT(eosio::chain_apis::read_only::get_producers_params, (json)(lower_bound)(limit))
 FC_REFLECT(eosio::chain_apis::read_only::get_producers_result, (producers)(total_producer_vote_weight)(more));
 


### PR DESCRIPTION
this pr adds a new endpoint to the chain plugin called get_actor that takes as input fio public key and returns the actor for the specified public key