### PR TITLE
add get_actor endpoint to chain_plugin

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -107,7 +107,7 @@ namespace eosio {
                                      CHAIN_RO_CALL(get_required_keys, 200),
                                      CHAIN_RO_CALL(get_transaction_id, 200),
                                      CHAIN_RO_CALL(get_fio_balance, 200),
-                                     CHAIN_RO_CALL(fio_public_key_to_account, 200),
+                                     CHAIN_RO_CALL(get_actor, 200),
                                      CHAIN_RO_CALL(get_fio_names, 200),
                                      CHAIN_RO_CALL(get_fio_domains, 200),
                                      CHAIN_RO_CALL(get_fio_addresses, 200),

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -107,6 +107,7 @@ namespace eosio {
                                      CHAIN_RO_CALL(get_required_keys, 200),
                                      CHAIN_RO_CALL(get_transaction_id, 200),
                                      CHAIN_RO_CALL(get_fio_balance, 200),
+                                     CHAIN_RO_CALL(fio_public_key_to_account, 200),
                                      CHAIN_RO_CALL(get_fio_names, 200),
                                      CHAIN_RO_CALL(get_fio_domains, 200),
                                      CHAIN_RO_CALL(get_fio_addresses, 200),

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2717,20 +2717,18 @@ result.balance = rVal;
 return result;
 } //get_fio_balance
 
-        read_only::fio_public_key_to_account_result read_only::fio_public_key_to_account(const read_only::fio_public_key_to_account_params &p) const {
-            string fioKey = p.fio_public_key;
-            fioio::replaceFormat(fioKey);
-            FIO_400_ASSERT(fioio::isPubKeyValid(fioKey), "fio_public_key", p.fio_public_key.c_str(),
+        read_only::get_actor_result read_only::get_actor(const read_only::get_actor_params &p) const {
+
+            FIO_400_ASSERT(fioio::isPubKeyValid(p.fio_public_key), "fio_public_key", p.fio_public_key.c_str(),
                            "Invalid FIO Public Key",
                            fioio::ErrorPubKeyValid);
+            get_actor_result result;
             string account_name;
             fioio::key_to_account(p.fio_public_key, account_name);
+            result.actor = account_name;
+            return result;
+        } //get_actor
 
-            fio_public_key_to_account_result r;
-            r.account = account_name;
-            return r;
-
-        } //fio_public_key_to_account
 
         /*** v1/chain/get_fee
         * Retrieves the fee associated with the specified fio address and blockchain endpoint

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2656,66 +2656,66 @@ if( options.count(name) ) { \
         } // get_fio_addresses
 
         read_only::get_fio_balance_result read_only::get_fio_balance(const read_only::get_fio_balance_params &p) const {
-        string fioKey = p.fio_public_key;
-        fioio::replaceFormat(fioKey);
-        FIO_400_ASSERT(fioio::isPubKeyValid(fioKey), "fio_public_key", p.fio_public_key.c_str(),
-        "Invalid FIO Public Key",
-        fioio::ErrorPubKeyValid);
+            string fioKey = p.fio_public_key;
+            fioio::replaceFormat(fioKey);
+            FIO_400_ASSERT(fioio::isPubKeyValid(fioKey), "fio_public_key", p.fio_public_key.c_str(),
+                           "Invalid FIO Public Key",
+                           fioio::ErrorPubKeyValid);
 
-        get_account_results actor_lookup_results;
-        get_account_params actor_lookup_params;
-        get_fio_balance_result result;
-        vector<asset> cursor;
-        result.balance = 0;
+            get_account_results actor_lookup_results;
+            get_account_params actor_lookup_params;
+            get_fio_balance_result result;
+            vector<asset> cursor;
+            result.balance = 0;
 
-        uint128_t keyhash = fioio::string_to_uint128_t(fioKey.c_str());
-        const abi_def system_abi = eosio::chain_apis::get_abi(db, fio_system_code);
+            uint128_t keyhash = fioio::string_to_uint128_t(fioKey.c_str());
+            const abi_def system_abi = eosio::chain_apis::get_abi(db, fio_system_code);
 
-        std::string hexvalkeyhash = "0x";
-        hexvalkeyhash.append(
-                fioio::to_hex_little_endian(reinterpret_cast<const char *>(&keyhash), sizeof(keyhash)));
+            std::string hexvalkeyhash = "0x";
+            hexvalkeyhash.append(
+                    fioio::to_hex_little_endian(reinterpret_cast<const char *>(&keyhash), sizeof(keyhash)));
 
 
-        get_table_rows_params eosio_table_row_params = get_table_rows_params{
-                .json           = true,
-                .code           = fio_system_code,
-                .scope          = fio_system_scope,
-                .table          = fio_accounts_table,
-                .lower_bound    = hexvalkeyhash,
-                .upper_bound    = hexvalkeyhash,
-                .key_type       = "hex",
-                .index_position = "2"};
+            get_table_rows_params eosio_table_row_params = get_table_rows_params{
+                    .json           = true,
+                    .code           = fio_system_code,
+                    .scope          = fio_system_scope,
+                    .table          = fio_accounts_table,
+                    .lower_bound    = hexvalkeyhash,
+                    .upper_bound    = hexvalkeyhash,
+                    .key_type       = "hex",
+                    .index_position = "2"};
 
-        get_table_rows_result account_result =
-                get_table_rows_by_seckey<index128_index, uint128_t>(
-                        eosio_table_row_params, system_abi, [](uint128_t v) -> uint128_t {
-                            return v;
-                        });
+            get_table_rows_result account_result =
+                    get_table_rows_by_seckey<index128_index, uint128_t>(
+                            eosio_table_row_params, system_abi, [](uint128_t v) -> uint128_t {
+                                return v;
+                            });
 
-        FIO_404_ASSERT(!account_result.rows.empty(), "Public key not found", fioio::ErrorPubAddressNotFound);
+            FIO_404_ASSERT(!account_result.rows.empty(), "Public key not found", fioio::ErrorPubAddressNotFound);
 
-        string fio_account = account_result.rows[0]["account"].as_string();
-        actor_lookup_params.account_name = fio_account;
+            string fio_account = account_result.rows[0]["account"].as_string();
+            actor_lookup_params.account_name = fio_account;
 
-    try {
-        actor_lookup_results = get_account(actor_lookup_params);
-    }
-    catch (...) {
-    FIO_404_ASSERT(false, "Public key not found", fioio::ErrorPubAddressNotFound);
-}
+            try {
+                actor_lookup_results = get_account(actor_lookup_params);
+            }
+            catch (...) {
+                FIO_404_ASSERT(false, "Public key not found", fioio::ErrorPubAddressNotFound);
+            }
 
-get_currency_balance_params balance_params;
-balance_params.code = ::eosio::string_to_name("fio.token");
-balance_params.account = ::eosio::string_to_name(fio_account.c_str());
-cursor = get_currency_balance(balance_params);
+            get_currency_balance_params balance_params;
+            balance_params.code = ::eosio::string_to_name("fio.token");
+            balance_params.account = ::eosio::string_to_name(fio_account.c_str());
+            cursor = get_currency_balance(balance_params);
 
-if (!cursor.empty()) {
-uint64_t rVal = (uint64_t) cursor[0].get_amount();
-result.balance = rVal;
-}
+            if (!cursor.empty()) {
+                uint64_t rVal = (uint64_t) cursor[0].get_amount();
+                result.balance = rVal;
+            }
 
-return result;
-} //get_fio_balance
+            return result;
+        } //get_fio_balance
 
         read_only::get_actor_result read_only::get_actor(const read_only::get_actor_params &p) const {
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -588,15 +588,15 @@ namespace eosio {
 
             get_fio_balance_result get_fio_balance(const get_fio_balance_params &params) const;
 
-            struct fio_public_key_to_account_params {
+            struct get_actor_params {
                 fc::string fio_public_key;
             };
 
-            struct fio_public_key_to_account_result {
-                string account;
+            struct get_actor_result {
+                string actor;
             };
 
-            fio_public_key_to_account_result fio_public_key_to_account(const fio_public_key_to_account_params &params) const;
+            get_actor_result get_actor(const get_actor_params &params) const;
 
             void obt_data_search(uint32_t search_limit, get_obt_data_result &result, const abi_def &reqobt_abi,
                                  const get_table_rows_result &table_rows_result, uint32_t &search_results,
@@ -1449,8 +1449,8 @@ FC_REFLECT(eosio::chain_apis::read_only::get_currency_stats_params, (code)(symbo
 FC_REFLECT(eosio::chain_apis::read_only::get_currency_stats_result, (supply)(max_supply)(issuer));
 FC_REFLECT(eosio::chain_apis::read_only::get_fio_balance_params, (fio_public_key));
 FC_REFLECT(eosio::chain_apis::read_only::get_fio_balance_result, (balance));
-FC_REFLECT(eosio::chain_apis::read_only::fio_public_key_to_account_params, (fio_public_key));
-FC_REFLECT(eosio::chain_apis::read_only::fio_public_key_to_account_result, (account));
+FC_REFLECT(eosio::chain_apis::read_only::get_actor_params, (fio_public_key));
+FC_REFLECT(eosio::chain_apis::read_only::get_actor_result, (actor));
 FC_REFLECT(eosio::chain_apis::read_only::get_producers_params, (json)(lower_bound)(limit))
 FC_REFLECT(eosio::chain_apis::read_only::get_producers_result, (producers)(total_producer_vote_weight)(more));
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -588,6 +588,16 @@ namespace eosio {
 
             get_fio_balance_result get_fio_balance(const get_fio_balance_params &params) const;
 
+            struct fio_public_key_to_account_params {
+                fc::string fio_public_key;
+            };
+
+            struct fio_public_key_to_account_result {
+                string account;
+            };
+
+            fio_public_key_to_account_result fio_public_key_to_account(const fio_public_key_to_account_params &params) const;
+
             void obt_data_search(uint32_t search_limit, get_obt_data_result &result, const abi_def &reqobt_abi,
                                  const get_table_rows_result &table_rows_result, uint32_t &search_results,
                                  uint32_t &search_offset, uint32_t &returnCount, bool &search_finished,
@@ -1439,6 +1449,8 @@ FC_REFLECT(eosio::chain_apis::read_only::get_currency_stats_params, (code)(symbo
 FC_REFLECT(eosio::chain_apis::read_only::get_currency_stats_result, (supply)(max_supply)(issuer));
 FC_REFLECT(eosio::chain_apis::read_only::get_fio_balance_params, (fio_public_key));
 FC_REFLECT(eosio::chain_apis::read_only::get_fio_balance_result, (balance));
+FC_REFLECT(eosio::chain_apis::read_only::fio_public_key_to_account_params, (fio_public_key));
+FC_REFLECT(eosio::chain_apis::read_only::fio_public_key_to_account_result, (account));
 FC_REFLECT(eosio::chain_apis::read_only::get_producers_params, (json)(lower_bound)(limit))
 FC_REFLECT(eosio::chain_apis::read_only::get_producers_result, (producers)(total_producer_vote_weight)(more));
 


### PR DESCRIPTION
this PR adds a new endpoint get_actor which takes a public key as input and returns the actor name associated with the specified public key