### PR TITLE
HOTFIX -- MERGE BY ERIC ONLY,  fee voting is broken on main net, Fix secondary index in fees table lookups in fee update

### DIFF
--- a/fio.contracts/contracts/fio.fee/fio.fee.cpp
+++ b/fio.contracts/contracts/fio.fee/fio.fee.cpp
@@ -59,7 +59,7 @@ namespace fioio {
 
 
 
-            auto feevotesbyendpoint = feevotes.get_index<"byendpoint"_n>();
+            auto feevotesbyendpoint = feevotes.get_index<"byendphash"_n>();
             string lastvalUsed = "";
             uint64_t lastusedHash;
             vector <uint64_t> feevalues;
@@ -111,7 +111,7 @@ namespace fioio {
         * @param fee_endpoint_hash
         */
         void
-        compute_median_and_update_fees(vector <uint64_t> feevalues, string fee_endpoint, uint128_t fee_endpoint_hash) {
+        compute_median_and_update_fees(vector <uint64_t> feevalues,  string fee_endpoint, uint128_t fee_endpoint_hash) {
             bool dbgout = true;
             //one more time
             if (feevalues.size() > 0) {
@@ -135,24 +135,18 @@ namespace fioio {
                 }
                 //update the fee.
                 auto feesbyendpoint = fiofees.get_index<"byendpoint"_n>();
-                bool found = false;
-                for (auto &fee_iter : feesbyendpoint) {
-                   // auto fee_iter = feesbyendpoint.find(fee_endpoint_hash);
-                   if (fee_iter.end_point.compare(fee_endpoint) == 0) {
-                       if (dbgout) {
-                        print(" EDEDEDEDEDEDED updating ", fee_iter.end_point, " to have fee ", median_fee, "\n");
-                       }
-                       fiofees.modify(fee_iter, _self, [&](struct fiofee &ff) {
-                          ff.suf_amount = median_fee;
-                       });
-                       found=true;
-                       break;
-                   }
-                }
-                if (!found){
+                auto fee_iter = feesbyendpoint.find(fee_endpoint_hash);
+                if (fee_iter != feesbyendpoint.end()) {
+                    if (dbgout) {
+                        print(" EDEDEDEDEDEDED updating ", fee_iter->end_point, " to have fee ", median_fee, "\n");
+                    }
+                    feesbyendpoint.modify(fee_iter, _self, [&](struct fiofee &ff) {
+                        ff.suf_amount = median_fee;
+                    });
+                } else {
                     if (dbgout) {
                         print(" EDEDEDEDEDEDEDED fee endpoint does not exist in fiofees for endpoint ", fee_endpoint,
-                                  " computed median is ", median_fee, "failed to update fee" "\n");
+                              " computed median is ", median_fee, "failed to update fee" "\n");
                     }
                 }
             }

--- a/fio.contracts/contracts/fio.fee/fio.fee.cpp
+++ b/fio.contracts/contracts/fio.fee/fio.fee.cpp
@@ -138,7 +138,7 @@ namespace fioio {
                 bool found = false;
                 for (auto &fee_iter : feesbyendpoint) {
                    // auto fee_iter = feesbyendpoint.find(fee_endpoint_hash);
-                   if (fee_iter.end_point.compare(fee_endpoint) != 0) {
+                   if (fee_iter.end_point.compare(fee_endpoint) == 0) {
                        if (dbgout) {
                         print(" EDEDEDEDEDEDED updating ", fee_iter.end_point, " to have fee ", median_fee, "\n");
                        }

--- a/fio.contracts/contracts/fio.fee/fio.fee.cpp
+++ b/fio.contracts/contracts/fio.fee/fio.fee.cpp
@@ -68,7 +68,7 @@ namespace fioio {
                 //if we have changed the endpoint name then we are in the next endpoints grouping,
                 // so compute median fee for this endpoint and then clear the list.
                 if (vote_item.end_point.compare(lastvalUsed) != 0) {
-                    print(" EDEDEDEDED computing median for '", lastvalUsed, "'","\n");
+                    print(" EDEDEDEDED computing median for '", lastvalUsed, "' hash is ", lastusedHash,"\n");
                     compute_median_and_update_fees(feevalues, lastvalUsed, lastusedHash);
 
                     feevalues.clear();

--- a/fio.contracts/contracts/fio.fee/fio.fee.cpp
+++ b/fio.contracts/contracts/fio.fee/fio.fee.cpp
@@ -37,10 +37,11 @@ namespace fioio {
         void update_fees() {
             map<string, double> producer_fee_multipliers_map;
 
-            const bool dbgout = false;
+            const bool dbgout = true;
 
             //Selecting only elected producers, create a map for each producer and its associated multiplier
             //for use in performing the multiplications later,
+            print("EDEDEDED inside update_fees", "\n");
             auto topprod = topprods.begin();
             while (topprod != topprods.end()) {
 
@@ -49,7 +50,7 @@ namespace fioio {
 
                     if (voters_iter != feevoters.end()) {
                         if (dbgout) {
-                            print(" adding producer to multiplier map", v1.c_str(), "\n");
+                            print(" EDEDEDEDED adding producer to multiplier map", v1.c_str(), "\n");
                         }
                         producer_fee_multipliers_map.insert(make_pair(v1, voters_iter->fee_multiplier));
                     }
@@ -67,6 +68,7 @@ namespace fioio {
                 //if we have changed the endpoint name then we are in the next endpoints grouping,
                 // so compute median fee for this endpoint and then clear the list.
                 if (vote_item.end_point.compare(lastvalUsed) != 0) {
+                    print(" EDEDEDEDED computing median for '", lastvalUsed, "'","\n");
                     compute_median_and_update_fees(feevalues, lastvalUsed, lastusedHash);
 
                     feevalues.clear();
@@ -89,6 +91,7 @@ namespace fioio {
 
                     const uint64_t voted_fee = (uint64_t)(dresult);
                     feevalues.push_back(voted_fee);
+                    print(" EDEDEDEDED adding fee vote value ",voted_fee," for voter '", vote_item.block_producer_name.to_string(), "'","\n");
                 }
             }
 
@@ -109,9 +112,10 @@ namespace fioio {
         */
         void
         compute_median_and_update_fees(vector <uint64_t> feevalues, string fee_endpoint, uint128_t fee_endpoint_hash) {
-            bool dbgout = false;
+            bool dbgout = true;
             //one more time
             if (feevalues.size() > 0) {
+                print("EDEDEDEDED inside compute median and update fees greater than zero fee values ","\n");
                 uint64_t median_fee = 0;
                 //sort it.
                 sort(feevalues.begin(), feevalues.end());
@@ -119,13 +123,13 @@ namespace fioio {
                 if ((feevalues.size() % 2) == 1) {
                     const int useIdx = (feevalues.size() / 2);
                     if (dbgout) {
-                        print(" odd size is ", feevalues.size(), " using index for median ", useIdx, "\n");
+                        print(" EDEDEDEDEDE odd size is ", feevalues.size(), " using index for median ", useIdx, "\n");
                     }
                     median_fee = feevalues[useIdx];
                 } else {//even number in the list. use the middle 2
                     const int useIdx = (feevalues.size() / 2) - 1;
                     if (dbgout) {
-                        print(" even size is ", feevalues.size(), " using index for median ", useIdx, "\n");
+                        print(" EDEDEDEDEDEDED even size is ", feevalues.size(), " using index for median ", useIdx, "\n");
                     }
                     median_fee = (feevalues[useIdx] + feevalues[useIdx + 1]) / 2;
                 }
@@ -134,15 +138,15 @@ namespace fioio {
                 auto fee_iter = feesbyendpoint.find(fee_endpoint_hash);
                 if (fee_iter != feesbyendpoint.end()) {
                     if (dbgout) {
-                        print(" updating ", fee_iter->end_point, " to have fee ", median_fee, "\n");
+                        print(" EDEDEDEDEDEDED updating ", fee_iter->end_point, " to have fee ", median_fee, "\n");
                     }
                     feesbyendpoint.modify(fee_iter, _self, [&](struct fiofee &ff) {
                         ff.suf_amount = median_fee;
                     });
                 } else {
                     if (dbgout) {
-                        print(" fee endpoint does not exist in fiofees for endpoint ", fee_endpoint,
-                              " computed median is ", median_fee, "\n");
+                        print(" EDEDEDEDEDEDEDED fee endpoint does not exist in fiofees for endpoint ", fee_endpoint,
+                              " computed median is ", median_fee, "failed to update fee" "\n");
                     }
                 }
             }

--- a/fio.contracts/contracts/fio.fee/fio.fee.cpp
+++ b/fio.contracts/contracts/fio.fee/fio.fee.cpp
@@ -135,18 +135,24 @@ namespace fioio {
                 }
                 //update the fee.
                 auto feesbyendpoint = fiofees.get_index<"byendpoint"_n>();
-                auto fee_iter = feesbyendpoint.find(fee_endpoint_hash);
-                if (fee_iter != feesbyendpoint.end()) {
-                    if (dbgout) {
-                        print(" EDEDEDEDEDEDED updating ", fee_iter->end_point, " to have fee ", median_fee, "\n");
-                    }
-                    feesbyendpoint.modify(fee_iter, _self, [&](struct fiofee &ff) {
-                        ff.suf_amount = median_fee;
-                    });
-                } else {
+                bool found = false;
+                for (auto &fee_iter : feesbyendpoint) {
+                   // auto fee_iter = feesbyendpoint.find(fee_endpoint_hash);
+                   if (fee_iter.end_point.compare(fee_endpoint) != 0) {
+                       if (dbgout) {
+                        print(" EDEDEDEDEDEDED updating ", fee_iter.end_point, " to have fee ", median_fee, "\n");
+                       }
+                       fiofees.modify(fee_iter, _self, [&](struct fiofee &ff) {
+                          ff.suf_amount = median_fee;
+                       });
+                       found=true;
+                       break;
+                   }
+                }
+                if (!found){
                     if (dbgout) {
                         print(" EDEDEDEDEDEDEDED fee endpoint does not exist in fiofees for endpoint ", fee_endpoint,
-                              " computed median is ", median_fee, "failed to update fee" "\n");
+                                  " computed median is ", median_fee, "failed to update fee" "\n");
                     }
                 }
             }

--- a/fio.contracts/contracts/fio.fee/fio.fee.cpp
+++ b/fio.contracts/contracts/fio.fee/fio.fee.cpp
@@ -59,9 +59,9 @@ namespace fioio {
 
 
 
-            auto feevotesbyendpoint = feevotes.get_index<"byendphash"_n>();
+            auto feevotesbyendpoint = feevotes.get_index<"byendpoint"_n>();
             string lastvalUsed = "";
-            uint64_t lastusedHash;
+            uint128_t lastusedHash;
             vector <uint64_t> feevalues;
             //traverse all of the fee votes grouped by endpoint.
             for (const auto &vote_item : feevotesbyendpoint) {

--- a/fio.contracts/contracts/fio.fee/fio.fee.cpp
+++ b/fio.contracts/contracts/fio.fee/fio.fee.cpp
@@ -37,11 +37,10 @@ namespace fioio {
         void update_fees() {
             map<string, double> producer_fee_multipliers_map;
 
-            const bool dbgout = true;
+            const bool dbgout = false;
 
             //Selecting only elected producers, create a map for each producer and its associated multiplier
             //for use in performing the multiplications later,
-            print("EDEDEDED inside update_fees", "\n");
             auto topprod = topprods.begin();
             while (topprod != topprods.end()) {
 
@@ -50,7 +49,7 @@ namespace fioio {
 
                     if (voters_iter != feevoters.end()) {
                         if (dbgout) {
-                            print(" EDEDEDEDED adding producer to multiplier map", v1.c_str(), "\n");
+                            print(" adding producer to multiplier map", v1.c_str(), "\n");
                         }
                         producer_fee_multipliers_map.insert(make_pair(v1, voters_iter->fee_multiplier));
                     }
@@ -68,7 +67,6 @@ namespace fioio {
                 //if we have changed the endpoint name then we are in the next endpoints grouping,
                 // so compute median fee for this endpoint and then clear the list.
                 if (vote_item.end_point.compare(lastvalUsed) != 0) {
-                    print(" EDEDEDEDED computing median for '", lastvalUsed, "' hash is ", lastusedHash,"\n");
                     compute_median_and_update_fees(feevalues, lastvalUsed, lastusedHash);
 
                     feevalues.clear();
@@ -91,7 +89,6 @@ namespace fioio {
 
                     const uint64_t voted_fee = (uint64_t)(dresult);
                     feevalues.push_back(voted_fee);
-                    print(" EDEDEDEDED adding fee vote value ",voted_fee," for voter '", vote_item.block_producer_name.to_string(), "'","\n");
                 }
             }
 
@@ -112,10 +109,9 @@ namespace fioio {
         */
         void
         compute_median_and_update_fees(vector <uint64_t> feevalues,  string fee_endpoint, uint128_t fee_endpoint_hash) {
-            bool dbgout = true;
+            bool dbgout = false;
             //one more time
             if (feevalues.size() > 0) {
-                print("EDEDEDEDED inside compute median and update fees greater than zero fee values ","\n");
                 uint64_t median_fee = 0;
                 //sort it.
                 sort(feevalues.begin(), feevalues.end());
@@ -123,13 +119,13 @@ namespace fioio {
                 if ((feevalues.size() % 2) == 1) {
                     const int useIdx = (feevalues.size() / 2);
                     if (dbgout) {
-                        print(" EDEDEDEDEDE odd size is ", feevalues.size(), " using index for median ", useIdx, "\n");
+                        print(" odd size is ", feevalues.size(), " using index for median ", useIdx, "\n");
                     }
                     median_fee = feevalues[useIdx];
                 } else {//even number in the list. use the middle 2
                     const int useIdx = (feevalues.size() / 2) - 1;
                     if (dbgout) {
-                        print(" EDEDEDEDEDEDED even size is ", feevalues.size(), " using index for median ", useIdx, "\n");
+                        print(" even size is ", feevalues.size(), " using index for median ", useIdx, "\n");
                     }
                     median_fee = (feevalues[useIdx] + feevalues[useIdx + 1]) / 2;
                 }
@@ -138,14 +134,14 @@ namespace fioio {
                 auto fee_iter = feesbyendpoint.find(fee_endpoint_hash);
                 if (fee_iter != feesbyendpoint.end()) {
                     if (dbgout) {
-                        print(" EDEDEDEDEDEDED updating ", fee_iter->end_point, " to have fee ", median_fee, "\n");
+                        print(" updating ", fee_iter->end_point, " to have fee ", median_fee, "\n");
                     }
                     feesbyendpoint.modify(fee_iter, _self, [&](struct fiofee &ff) {
                         ff.suf_amount = median_fee;
                     });
                 } else {
                     if (dbgout) {
-                        print(" EDEDEDEDEDEDEDED fee endpoint does not exist in fiofees for endpoint ", fee_endpoint,
+                        print(" fee endpoint does not exist in fiofees for endpoint ", fee_endpoint,
                               " computed median is ", median_fee, "failed to update fee" "\n");
                     }
                 }

--- a/fio.contracts/contracts/fio.fee/fio.fee.cpp
+++ b/fio.contracts/contracts/fio.fee/fio.fee.cpp
@@ -108,7 +108,7 @@ namespace fioio {
         * @param fee_endpoint_hash
         */
         void
-        compute_median_and_update_fees(vector <uint64_t> feevalues,  string fee_endpoint, uint128_t fee_endpoint_hash) {
+        compute_median_and_update_fees(vector <uint64_t> feevalues,  const string &fee_endpoint, const uint128_t &fee_endpoint_hash) {
             bool dbgout = false;
             //one more time
             if (feevalues.size() > 0) {

--- a/fio.contracts/contracts/fio.fee/fio.fee.hpp
+++ b/fio.contracts/contracts/fio.fee/fio.fee.hpp
@@ -110,7 +110,7 @@ namespace fioio {
     };
 
     typedef multi_index<"feevotes"_n, feevote,
-            indexed_by<"byendphash"_n, const_mem_fun < feevote, uint128_t, &feevote::by_endpoint>>,
+            indexed_by<"byendpoint"_n, const_mem_fun < feevote, uint128_t, &feevote::by_endpoint>>,
             indexed_by<"bybpname"_n, const_mem_fun<feevote, uint64_t, &feevote::by_bpname>>
     >
     feevotes_table;

--- a/fio.contracts/contracts/fio.fee/fio.fee.hpp
+++ b/fio.contracts/contracts/fio.fee/fio.fee.hpp
@@ -102,17 +102,16 @@ namespace fioio {
         uint64_t lastvotetimestamp;
 
         uint64_t primary_key() const { return id; }
-        uint64_t by_bpname() const { return block_producer_name.value; }
         uint128_t by_endpoint() const { return end_point_hash; }
-
+        uint64_t by_bpname() const { return block_producer_name.value; }
 
         EOSLIB_SERIALIZE(feevote, (id)(block_producer_name)(end_point)(end_point_hash)(suf_amount)(lastvotetimestamp)
         )
     };
 
     typedef multi_index<"feevotes"_n, feevote,
-            indexed_by<"bybpname"_n, const_mem_fun<feevote, uint64_t, &feevote::by_bpname>>,
-            indexed_by<"byendpoint"_n, const_mem_fun < feevote, uint128_t, &feevote::by_endpoint>>
+            indexed_by<"byendphash"_n, const_mem_fun < feevote, uint128_t, &feevote::by_endpoint>>,
+            indexed_by<"bybpname"_n, const_mem_fun<feevote, uint64_t, &feevote::by_bpname>>
     >
     feevotes_table;
 } // namespace fioio

--- a/fio.contracts/contracts/fio.fee/fio.fee.hpp
+++ b/fio.contracts/contracts/fio.fee/fio.fee.hpp
@@ -102,16 +102,17 @@ namespace fioio {
         uint64_t lastvotetimestamp;
 
         uint64_t primary_key() const { return id; }
-        uint128_t by_endpoint() const { return end_point_hash; }
         uint64_t by_bpname() const { return block_producer_name.value; }
+        uint128_t by_endpoint() const { return end_point_hash; }
+
 
         EOSLIB_SERIALIZE(feevote, (id)(block_producer_name)(end_point)(end_point_hash)(suf_amount)(lastvotetimestamp)
         )
     };
 
     typedef multi_index<"feevotes"_n, feevote,
-            indexed_by<"byendpoint"_n, const_mem_fun < feevote, uint128_t, &feevote::by_endpoint>>,
-    indexed_by<"bybpname"_n, const_mem_fun<feevote, uint64_t, &feevote::by_bpname>>
+            indexed_by<"bybpname"_n, const_mem_fun<feevote, uint64_t, &feevote::by_bpname>>,
+            indexed_by<"byendpoint"_n, const_mem_fun < feevote, uint128_t, &feevote::by_endpoint>>
     >
     feevotes_table;
 } // namespace fioio

--- a/fio.contracts/contracts/fio.fee/fio.fee.hpp
+++ b/fio.contracts/contracts/fio.fee/fio.fee.hpp
@@ -102,7 +102,7 @@ namespace fioio {
         uint64_t lastvotetimestamp;
 
         uint64_t primary_key() const { return id; }
-        uint64_t by_endpoint() const { return end_point_hash; }
+        uint128_t by_endpoint() const { return end_point_hash; }
         uint64_t by_bpname() const { return block_producer_name.value; }
 
         EOSLIB_SERIALIZE(feevote, (id)(block_producer_name)(end_point)(end_point_hash)(suf_amount)(lastvotetimestamp)
@@ -110,7 +110,7 @@ namespace fioio {
     };
 
     typedef multi_index<"feevotes"_n, feevote,
-            indexed_by<"byendpoint"_n, const_mem_fun < feevote, uint64_t, &feevote::by_endpoint>>,
+            indexed_by<"byendpoint"_n, const_mem_fun < feevote, uint128_t, &feevote::by_endpoint>>,
     indexed_by<"bybpname"_n, const_mem_fun<feevote, uint64_t, &feevote::by_bpname>>
     >
     feevotes_table;


### PR DESCRIPTION
this PR fixes the secondary 128 bit index on the fees table providing lookup by endpoint name hash.
the code that uses the index also needed updating, had a 64 bit variable needing updated to 128

this was tested using a 24 node local testnet on azure, and testing with the soap ui tests.