### PR TITLE
ERIC TO REVIEW and MERGE please -- fee, and bundle count vote fixes for release/1.0.3

### DIFF
--- a/fio.contracts/contracts/fio.address/fio.address.cpp
+++ b/fio.contracts/contracts/fio.address/fio.address.cpp
@@ -17,6 +17,7 @@ namespace fioio {
     class [[eosio::contract("FioAddressLookup")]]  FioNameLookup : public eosio::contract {
 
     private:
+        const int MIN_VOTES_FOR_AVERAGING = 15;
         domains_table domains;
         fionames_table fionames;
         fiofee_table fiofees;
@@ -141,9 +142,9 @@ namespace fioio {
 
             size_t size = votes.size();
 
-            if (size == 0 ) {
+            if (size < MIN_VOTES_FOR_AVERAGING ) {
                 return DEFAULTBUNDLEAMT;
-            } else {
+            } else if (size >= MIN_VOTES_FOR_AVERAGING){
                 sort(votes.begin(), votes.end());
                 if (size % 2 == 0) {
                     return (votes[size / 2 - 1] + votes[size / 2]) / 2;
@@ -151,6 +152,7 @@ namespace fioio {
                     return votes[size / 2];
                 }
             }
+            return DEFAULTBUNDLEAMT;
         }
 
         uint32_t fio_address_update( const name &actor, const name &owner, const uint64_t max_fee, const FioAddress &fa,

--- a/fio.contracts/contracts/fio.fee/fio.fee.cpp
+++ b/fio.contracts/contracts/fio.fee/fio.fee.cpp
@@ -28,6 +28,7 @@ namespace fioio {
     class [[eosio::contract("FioFee")]]  FioFee : public eosio::contract {
 
     private:
+        const int MIN_FEE_VOTERS_FOR_MEDIAN = 15;
         fiofee_table fiofees;
         feevoters_table feevoters;
         bundlevoters_table bundlevoters;
@@ -60,7 +61,7 @@ namespace fioio {
 
             auto feevotesbyendpoint = feevotes.get_index<"byendpoint"_n>();
             string lastvalUsed = "";
-            uint64_t lastusedHash;
+            uint128_t lastusedHash;
             vector <uint64_t> feevalues;
             //traverse all of the fee votes grouped by endpoint.
             for (const auto &vote_item : feevotesbyendpoint) {
@@ -108,10 +109,10 @@ namespace fioio {
         * @param fee_endpoint_hash
         */
         void
-        compute_median_and_update_fees(vector <uint64_t> feevalues, string fee_endpoint, uint128_t fee_endpoint_hash) {
+        compute_median_and_update_fees(vector <uint64_t> feevalues, const string &fee_endpoint, const uint128_t &fee_endpoint_hash) {
             bool dbgout = false;
             //one more time
-            if (feevalues.size() > 0) {
+            if (feevalues.size() >= MIN_FEE_VOTERS_FOR_MEDIAN) {
                 uint64_t median_fee = 0;
                 //sort it.
                 sort(feevalues.begin(), feevalues.end());
@@ -142,7 +143,7 @@ namespace fioio {
                 } else {
                     if (dbgout) {
                         print(" fee endpoint does not exist in fiofees for endpoint ", fee_endpoint,
-                              " computed median is ", median_fee, "\n");
+                              " computed median is ", median_fee, " failed to update fee", "\n");
                     }
                 }
             }

--- a/fio.contracts/contracts/fio.fee/fio.fee.hpp
+++ b/fio.contracts/contracts/fio.fee/fio.fee.hpp
@@ -53,7 +53,7 @@ namespace fioio {
 
     typedef multi_index<"fiofees"_n, fiofee,
             indexed_by<"byendpoint"_n, const_mem_fun < fiofee, uint128_t, &fiofee::by_endpoint>>,
-    indexed_by<"bytype"_n, const_mem_fun<fiofee, uint64_t, &fiofee::by_type>
+            indexed_by<"bytype"_n, const_mem_fun<fiofee, uint64_t, &fiofee::by_type>
     >>
     fiofee_table;
 
@@ -102,7 +102,7 @@ namespace fioio {
         uint64_t lastvotetimestamp;
 
         uint64_t primary_key() const { return id; }
-        uint64_t by_endpoint() const { return end_point_hash; }
+        uint128_t by_endpoint() const { return end_point_hash; }
         uint64_t by_bpname() const { return block_producer_name.value; }
 
         EOSLIB_SERIALIZE(feevote, (id)(block_producer_name)(end_point)(end_point_hash)(suf_amount)(lastvotetimestamp)
@@ -110,8 +110,8 @@ namespace fioio {
     };
 
     typedef multi_index<"feevotes"_n, feevote,
-            indexed_by<"byendpoint"_n, const_mem_fun < feevote, uint64_t, &feevote::by_endpoint>>,
-    indexed_by<"bybpname"_n, const_mem_fun<feevote, uint64_t, &feevote::by_bpname>>
+            indexed_by<"byendpoint"_n, const_mem_fun < feevote, uint128_t, &feevote::by_endpoint>>,
+            indexed_by<"bybpname"_n, const_mem_fun<feevote, uint64_t, &feevote::by_bpname>>
     >
     feevotes_table;
 } // namespace fioio


### PR DESCRIPTION
this PR resolves the issue with fees not being written into the fees table after votes are processed.
this PR enforces that 15 votes are needed to vote for fees.
this PR enforces that 15 votes are needed before bundlecount votes will be processed.

these changes need to be tested on a 24 node test net..we need to make tests that will vote the necessary number of votes with active producer keys and such...