### PR TITLE
Fixes for TPID auto proxy, issue 141

### DIFF
--- a/fio.contracts/contracts/fio.address/fio.address.cpp
+++ b/fio.contracts/contracts/fio.address/fio.address.cpp
@@ -684,7 +684,7 @@ namespace fioio {
                            ErrorMaxFeeExceeded);
 
             fio_fees(actor, asset(reg_amount, FIOSYMBOL));
-            processbucketrewards(tpid, reg_amount, get_self(), actor);
+            processbucketrewards(tpid, reg_amount, get_self(), nm);
 
             if (REGADDRESSRAM > 0) {
                 action(

--- a/fio.contracts/contracts/fio.address/fio.address.cpp
+++ b/fio.contracts/contracts/fio.address/fio.address.cpp
@@ -684,7 +684,7 @@ namespace fioio {
                            ErrorMaxFeeExceeded);
 
             fio_fees(actor, asset(reg_amount, FIOSYMBOL));
-            processbucketrewar ds(tpid, reg_amount, get_self(), actor);
+            processbucketrewards(tpid, reg_amount, get_self(), actor);
 
             if (REGADDRESSRAM > 0) {
                 action(

--- a/fio.contracts/contracts/fio.address/fio.address.cpp
+++ b/fio.contracts/contracts/fio.address/fio.address.cpp
@@ -360,7 +360,7 @@ namespace fioio {
                 //NOTE -- question here, should we always record the transfer for the fees, even when its zero,
                 //or should we do as this code does and not do a transaction when the fees are 0.
                 fio_fees(actor, asset(reg_amount, FIOSYMBOL));
-                process_rewards(tpid, reg_amount, get_self());
+                process_rewards(tpid, reg_amount,get_self(), actor);
 
                 if (reg_amount > 0) {
                     INLINE_ACTION_SENDER(eosiosystem::system_contract, updatepower)
@@ -467,7 +467,7 @@ namespace fioio {
                 //NOTE -- question here, should we always record the transfer for the fees, even when its zero,
                 //or should we do as this code does and not do a transaction when the fees are 0.
                 fio_fees(actor, asset(reg_amount, FIOSYMBOL));
-                process_rewards(tpid, reg_amount, get_self());
+                process_rewards(tpid, reg_amount,get_self(), actor);
 
                 if (reg_amount > 0) {
                     INLINE_ACTION_SENDER(eosiosystem::system_contract, updatepower)
@@ -592,7 +592,7 @@ namespace fioio {
                 //NOTE -- question here, should we always record the transfer for the fees, even when its zero,
                 //or should we do as this code does and not do a transaction when the fees are 0.
                 fio_fees(actor, asset(reg_amount, FIOSYMBOL));
-                process_rewards(tpid, reg_amount, get_self());
+                process_rewards(tpid, reg_amount,get_self(), actor);
 
                 if (reg_amount > 0) {
                     INLINE_ACTION_SENDER(eosiosystem::system_contract, updatepower)
@@ -684,7 +684,7 @@ namespace fioio {
                            ErrorMaxFeeExceeded);
 
             fio_fees(actor, asset(reg_amount, FIOSYMBOL));
-            processbucketrewards(tpid, reg_amount, get_self());
+            processbucketrewar ds(tpid, reg_amount, get_self(), actor);
 
             if (REGADDRESSRAM > 0) {
                 action(
@@ -756,7 +756,7 @@ namespace fioio {
                            ErrorMaxFeeExceeded);
 
             fio_fees(actor, asset(reg_amount, FIOSYMBOL));
-            processbucketrewards(tpid, reg_amount, get_self());
+            processbucketrewards(tpid, reg_amount, get_self(), actor);
 
             const string response_string = string("{\"status\": \"OK\",\"expiration\":\"") +
                                    timebuffer + string("\",\"fee_collected\":") +
@@ -829,7 +829,7 @@ namespace fioio {
                            ErrorMaxFeeExceeded);
 
             fio_fees(actor, asset(reg_amount, FIOSYMBOL));
-            processbucketrewards(tpid, reg_amount, get_self());
+            processbucketrewards(tpid, reg_amount, get_self(),actor);
 
             const uint64_t new_expiration_time = get_time_plus_one_year(expiration_time);
 
@@ -931,7 +931,7 @@ namespace fioio {
                            ErrorMaxFeeExceeded);
 
             fio_fees(actor, asset(reg_amount, FIOSYMBOL));
-            processbucketrewards(tpid, reg_amount, get_self());
+            processbucketrewards(tpid, reg_amount, get_self(),actor);
 
             const uint64_t new_expiration_time = get_time_plus_one_year(expiration_time);
 
@@ -1291,7 +1291,7 @@ namespace fioio {
                            ErrorMaxFeeExceeded);
 
             fio_fees(actor, asset(reg_amount, FIOSYMBOL));
-            process_rewards(tpid, reg_amount, get_self());
+            process_rewards(tpid, reg_amount,get_self(), actor);
             if (reg_amount > 0) {
                 //MAS-522 remove staking from voting.
                 INLINE_ACTION_SENDER(eosiosystem::system_contract, updatepower)
@@ -1434,7 +1434,7 @@ namespace fioio {
                            ErrorMaxFeeExceeded);
 
             fio_fees(actor, asset(fee_amount, FIOSYMBOL));
-            processbucketrewards(tpid, fee_amount, get_self());
+            processbucketrewards(tpid, fee_amount, get_self(), actor);
 
             if (XFERRAM > 0) {
                 action(
@@ -1510,7 +1510,7 @@ namespace fioio {
                            ErrorMaxFeeExceeded);
 
             fio_fees(actor, asset(fee_amount, FIOSYMBOL));
-            processbucketrewards(tpid, fee_amount, get_self());
+            processbucketrewards(tpid, fee_amount, get_self(), actor);
 
             if (XFERRAM > 0) {
                 action(

--- a/fio.contracts/contracts/fio.common/fio.common.hpp
+++ b/fio.contracts/contracts/fio.common/fio.common.hpp
@@ -72,6 +72,23 @@ namespace fioio {
         }
     }
 
+
+    inline bool isFIOSystem(const name &actor){
+        return
+            (actor == fioio::MSIGACCOUNT ||
+             actor == fioio::WRAPACCOUNT ||
+             actor == fioio::SYSTEMACCOUNT ||
+             actor == fioio::ASSERTACCOUNT ||
+             actor == fioio::REQOBTACCOUNT ||
+             actor == fioio::FeeContract ||
+             actor == fioio::AddressContract ||
+             actor == fioio::TPIDContract ||
+             actor == fioio::TokenContract ||
+             actor == fioio::TREASURYACCOUNT ||
+             actor == fioio::FIOSYSTEMACCOUNT ||
+             actor == fioio::FIOACCOUNT);
+    }
+
     static constexpr uint64_t string_to_uint64_hash(const char *str) {
 
         uint32_t len = 0;
@@ -250,6 +267,7 @@ namespace fioio {
 
 
     void processbucketrewards(const string &tpid, const uint64_t &amount, const name &auth, const name &actor) {
+
 
         action(
                 permission_level{auth, "active"_n},

--- a/fio.contracts/contracts/fio.common/fio.common.hpp
+++ b/fio.contracts/contracts/fio.common/fio.common.hpp
@@ -188,10 +188,10 @@ namespace fioio {
 
     typedef singleton<"bounties"_n, bounty> bounties_table;
 
-    void process_rewards(const string &tpid, const uint64_t &amount, const name &actor) {
+    void process_rewards(const string &tpid, const uint64_t &amount, const name &auth, const name &actor) {
 
         action(
-                permission_level{actor, "active"_n},
+                permission_level{auth, "active"_n},
                 TREASURYACCOUNT,
                 "fdtnrwdupdat"_n,
                 std::make_tuple((uint64_t)(static_cast<double>(amount) * .05))
@@ -225,14 +225,14 @@ namespace fioio {
             }
 
             action(
-                    permission_level{actor, "active"_n},
+                    permission_level{auth, "active"_n},
                     TPIDContract,
                     "updatetpid"_n,
                     std::make_tuple(tpid, actor, (amount / 10) + bamount)
             ).send();
 
             action(
-                    permission_level{actor, "active"_n},
+                    permission_level{auth, "active"_n},
                     TREASURYACCOUNT,
                     "bprewdupdate"_n,
                     std::make_tuple((uint64_t)(static_cast<double>(amount) * .85))
@@ -240,7 +240,7 @@ namespace fioio {
 
         } else {
             action(
-                    permission_level{actor, "active"_n},
+                    permission_level{auth, "active"_n},
                     TREASURYACCOUNT,
                     "bprewdupdate"_n,
                     std::make_tuple((uint64_t)(static_cast<double>(amount) * .95))
@@ -249,10 +249,10 @@ namespace fioio {
     }
 
 
-    void processbucketrewards(const string &tpid, const uint64_t &amount, const name &actor) {
+    void processbucketrewards(const string &tpid, const uint64_t &amount, const name &auth, const name &actor) {
 
         action(
-                permission_level{actor, "active"_n},
+                permission_level{auth, "active"_n},
                 TREASURYACCOUNT,
                 "fdtnrwdupdat"_n,
                 std::make_tuple((uint64_t)(static_cast<double>(amount) * .05))
@@ -285,7 +285,7 @@ namespace fioio {
             }
 
             action(
-                    permission_level{actor, "active"_n},
+                    permission_level{auth, "active"_n},
                     TPIDContract,
                     "updatetpid"_n,
                     std::make_tuple(tpid, actor, (amount / 10) + bamount)
@@ -293,7 +293,7 @@ namespace fioio {
 
 
             action(
-                    permission_level{actor, "active"_n},
+                    permission_level{auth, "active"_n},
                     TREASURYACCOUNT,
                     "bppoolupdate"_n,
                     std::make_tuple((uint64_t)(static_cast<double>(amount) * .85))
@@ -301,7 +301,7 @@ namespace fioio {
         } else {
 
             action(
-                    permission_level{actor, "active"_n},
+                    permission_level{auth, "active"_n},
                     TREASURYACCOUNT,
                     "bppoolupdate"_n,
                     std::make_tuple((uint64_t)(static_cast<double>(amount) * .95))

--- a/fio.contracts/contracts/fio.common/fioerror.hpp
+++ b/fio.contracts/contracts/fio.common/fioerror.hpp
@@ -88,7 +88,8 @@ namespace fioio {
     constexpr auto ErrorDomainOwner = ident | httpInvalidError | 153;
     constexpr auto ErrorTransactionTooLarge = ident | httpDataError | 152;   // Transaction too large
     constexpr auto ErrorRequestStatusInvalid = ident | httpDataError | 153;   // the specified request context record was not found
-  
+    constexpr auto ErrorActorIsSystemAccount = ident | httpDataError | 154;   // the specified actor is a FIO system account
+
     /**
     * Helper funtions for detecting rich error messages and extracting bitfielded values
     */

--- a/fio.contracts/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/fio.contracts/contracts/fio.request.obt/fio.request.obt.cpp
@@ -170,7 +170,7 @@ namespace fioio {
                                ErrorMaxFeeExceeded);
 
                 fio_fees(aactor, asset(fee_amount, FIOSYMBOL));
-                process_rewards(tpid, fee_amount, get_self());
+                process_rewards(tpid, fee_amount, get_self(), aactor);
 
                 if (fee_amount > 0) {
                     INLINE_ACTION_SENDER(eosiosystem::system_contract, updatepower)
@@ -371,7 +371,7 @@ namespace fioio {
                                ErrorMaxFeeExceeded);
 
                 fio_fees(aActor, asset(fee_amount, FIOSYMBOL));
-                process_rewards(tpid, fee_amount, get_self());
+                process_rewards(tpid, fee_amount, get_self(),aActor);
 
                 if (fee_amount > 0) {
                     INLINE_ACTION_SENDER(eosiosystem::system_contract, updatepower)
@@ -529,7 +529,7 @@ namespace fioio {
                                ErrorMaxFeeExceeded);
 
                 fio_fees(aactor, asset(fee_amount, FIOSYMBOL));
-                process_rewards(tpid, fee_amount, get_self());
+                process_rewards(tpid, fee_amount, get_self(), aactor);
 
                 if (fee_amount > 0) {
                     INLINE_ACTION_SENDER(eosiosystem::system_contract, updatepower)
@@ -673,7 +673,7 @@ namespace fioio {
                            ErrorMaxFeeExceeded);
 
             fio_fees(aactor, asset(fee_amount, FIOSYMBOL));
-            process_rewards(tpid, fee_amount, get_self());
+            process_rewards(tpid, fee_amount, get_self(), aactor);
 
             if (fee_amount > 0) {
                 INLINE_ACTION_SENDER(eosiosystem::system_contract, updatepower)

--- a/fio.contracts/contracts/fio.system/src/voting.cpp
+++ b/fio.contracts/contracts/fio.system/src/voting.cpp
@@ -965,6 +965,8 @@ namespace eosiosystem {
     void system_contract::setautoproxy(const name &proxy,const name &owner)
     {
         require_auth(TPIDContract);
+
+
         fio_400_assert(!(isFIOSystem(owner)), "owner", "setautoproxy",
                        "Auto proxy cannot be to a system account", ErrorActorIsSystemAccount);
         fio_400_assert(!(isFIOSystem(proxy)), "proxy", "setautoproxy",
@@ -987,7 +989,11 @@ namespace eosiosystem {
 
     void system_contract::crautoproxy(const name &proxy,const name &owner)
     {
+        bool debug = false;
         require_auth(TPIDContract);
+        if (debug) {
+            print("calling create auto proxy ", proxy, " owner ", owner, "\n");
+        }
 
         fio_400_assert(!(isFIOSystem(owner)), "owner", "setautoproxy",
                 "Auto proxy cannot be to a system account", ErrorActorIsSystemAccount);
@@ -1002,6 +1008,9 @@ namespace eosiosystem {
 
         if (itervi != votersbyowner.end() &&
            itervi->is_proxy) {
+            if (debug) {
+                print("create auto proxy found the proxy ", proxy, "\n");
+            }
 
             auto itervoter = votersbyowner.find(owner.value);
             if (itervoter == votersbyowner.end()) {
@@ -1016,6 +1025,11 @@ namespace eosiosystem {
                 votersbyowner.modify(itervoter, _self, [&](struct voter_info &a) {
                     a.proxy = proxy;
                 });
+            }
+        }
+        else{
+            if (debug) {
+                print("create auto proxy didnt find the proxy ", proxy, "\n");
             }
         }
     }

--- a/fio.contracts/contracts/fio.system/src/voting.cpp
+++ b/fio.contracts/contracts/fio.system/src/voting.cpp
@@ -965,6 +965,10 @@ namespace eosiosystem {
     void system_contract::setautoproxy(const name &proxy,const name &owner)
     {
         require_auth(TPIDContract);
+        fio_400_assert(!(isFIOSystem(owner)), "owner", "setautoproxy",
+                       "Auto proxy cannot be to a system account", ErrorActorIsSystemAccount);
+        fio_400_assert(!(isFIOSystem(proxy)), "proxy", "setautoproxy",
+                "proxy cannot be a from system account", ErrorActorIsSystemAccount);
         //first verify that the proxy exists and is registered as a proxy.
         //look it up and check it.
         //if its there then emplace the owner record into the voting_info table with is_auto_proxy set.
@@ -984,6 +988,12 @@ namespace eosiosystem {
     void system_contract::crautoproxy(const name &proxy,const name &owner)
     {
         require_auth(TPIDContract);
+
+        fio_400_assert(!(isFIOSystem(owner)), "owner", "setautoproxy",
+                "Auto proxy cannot be to a system account", ErrorActorIsSystemAccount);
+        fio_400_assert(!(isFIOSystem(proxy)), "proxy", "setautoproxy",
+                "proxy cannot be a from system account", ErrorActorIsSystemAccount);
+
         //first verify that the proxy exists and is registered as a proxy.
         //look it up and check it.
         //if its there then emplace the owner record into the voting_info table with is_auto_proxy set.

--- a/fio.contracts/contracts/fio.token/src/fio.token.cpp
+++ b/fio.contracts/contracts/fio.token/src/fio.token.cpp
@@ -309,7 +309,7 @@ namespace eosio {
         }
 
         fio_fees(actor, asset{(int64_t) reg_amount, FIOSYMBOL});
-        process_rewards(tpid, reg_amount, get_self());
+        process_rewards(tpid, reg_amount,get_self(), actor);
 
         require_recipient(actor);
 

--- a/fio.contracts/contracts/fio.token/src/fio.token.cpp
+++ b/fio.contracts/contracts/fio.token/src/fio.token.cpp
@@ -309,7 +309,7 @@ namespace eosio {
         }
 
         fio_fees(actor, asset{(int64_t) reg_amount, FIOSYMBOL});
-        process_rewards(tpid, reg_amount,get_self(), actor);
+        process_rewards(tpid, reg_amount,get_self(), new_account_name);
 
         require_recipient(actor);
 

--- a/fio.contracts/contracts/fio.tpid/fio.tpid.cpp
+++ b/fio.contracts/contracts/fio.tpid/fio.tpid.cpp
@@ -1,6 +1,6 @@
 /** FioTPID implementation file
  *  Description:
- *  @author Adam Androulidakis
+ *  @author Adam Androulidakis, Ed Rotthoff
  *  @modifedby
  *  @file fio.tpid.cpp
  *  @license FIO Foundation ( https://github.com/fioprotocol/fio/blob/master/LICENSE ) Dapix

--- a/fio.contracts/contracts/fio.tpid/fio.tpid.cpp
+++ b/fio.contracts/contracts/fio.tpid/fio.tpid.cpp
@@ -17,6 +17,7 @@ private:
         fionames_table fionames;
         eosiosystem::voters_table voters;
         bounties_table bounties;
+        bool debugout = false;
 
 public:
         using contract::contract;
@@ -67,6 +68,9 @@ public:
                 const auto tpidsbyname = tpids.get_index<"byname"_n>();
                 auto iter = tpidsbyname.find(hashname);
                 if (iter != tpidsbyname.end()) {
+                    if (debugout) {
+                        print("process auto proxy found tpid ", tpid, "\n");
+                    }
                         //tpid exists, use the info to find the owner of the tpid
                         auto namesbyname = fionames.get_index<"byname"_n>();
                         auto iternm = namesbyname.find(iter->fioaddhash);
@@ -75,6 +79,11 @@ public:
                                 //do the auto proxy
                                 autoproxy(proxy_name, owner);
                         }
+                }
+                else{
+                    if (debugout) {
+                        print("process auto proxy did not find tpid ", tpid, "\n");
+                    }
                 }
         }
 
@@ -88,6 +97,9 @@ public:
                 eosio_assert(has_auth(AddressContract) || has_auth(TokenContract) || has_auth(TREASURYACCOUNT) ||
                              has_auth("fio.reqobt"_n) || has_auth("eosio"_n),
                              "missing required authority of fio.address, fio.treasury, fio.token, eosio or fio.reqobt");
+            if (debugout) {
+                print("update tpid calling updatetpid with tpid ", tpid, " owner ", owner, "\n");
+            }
                 const auto tpidhash = string_to_uint128_hash(tpid.c_str());
                 auto tpidsbyname = tpids.get_index<"byname"_n>();
                 if (tpidsbyname.find(tpidhash) == tpidsbyname.end()) {
@@ -100,8 +112,8 @@ public:
                                         f.rewards = 0;
                                 });
 
-                        process_auto_proxy(tpid, owner);
                 }
+                process_auto_proxy(tpid, owner);
                 //Update existing tpid amount or amount of tpid that was just created before
                 tpidsbyname.modify(tpidsbyname.find(tpidhash), get_self(), [&](struct tpid &f) {
                                 f.rewards += amount;


### PR DESCRIPTION
this PR fixes this issue https://github.com/fioprotocol/fio/issues/141
this PR ensures that calls to the update tpid have the correct actor and so the correct entry will be made into the voters table going forward.

this PR requires more intensive testing using TPIDs to verify auto proxy is set up correctly whenever a tpid is used and no proxy is set by the calling account.
