### PR TITLE
Revert Pub_K1 replace solution.

### DIFF
--- a/libraries/chain/include/eosio/chain/fioio/pubkey_validation.hpp
+++ b/libraries/chain/include/eosio/chain/fioio/pubkey_validation.hpp
@@ -39,13 +39,4 @@ namespace fioio {
 
         return true;
     }
-
-    inline bool replaceFormat(string& str) {
-        std::string from = "PUB_K1_";
-        size_t start_pos = str.find(from);
-        if(start_pos == std::string::npos)
-            return false;
-        str.replace(start_pos, from.length(), "FIO");
-        return true;
-    }
 }

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1633,7 +1633,6 @@ if( options.count(name) ) { \
         read_only::get_pending_fio_requests_result
         read_only::get_pending_fio_requests(const read_only::get_pending_fio_requests_params &p) const {
             string fioKey = p.fio_public_key;
-            fioio::replaceFormat(fioKey);
             FIO_400_ASSERT(fioio::isPubKeyValid(fioKey), "fio_public_key", p.fio_public_key.c_str(),
                            "Invalid FIO Public Key",
                            fioio::ErrorPubKeyValid);
@@ -1809,7 +1808,6 @@ if( options.count(name) ) { \
         read_only::get_cancelled_fio_requests_result
         read_only::get_cancelled_fio_requests(const read_only::get_cancelled_fio_requests_params &p) const {
             string fioKey = p.fio_public_key;
-            fioio::replaceFormat(fioKey);
             FIO_400_ASSERT(fioio::isPubKeyValid(fioKey), "fio_public_key", p.fio_public_key.c_str(),
                            "Invalid FIO Public Key",
                            fioio::ErrorPubKeyValid);
@@ -1980,7 +1978,6 @@ if( options.count(name) ) { \
         read_only::get_sent_fio_requests_result
         read_only::get_sent_fio_requests(const read_only::get_sent_fio_requests_params &p) const {
             string fioKey = p.fio_public_key;
-            fioio::replaceFormat(fioKey);
             FIO_400_ASSERT(fioio::isPubKeyValid(fioKey), "fio_public_key", p.fio_public_key.c_str(),
                            "Invalid FIO Public Key",
                            fioio::ErrorPubKeyValid);
@@ -2144,7 +2141,6 @@ if( options.count(name) ) { \
         read_only::get_obt_data_result
         read_only::get_obt_data(const read_only::get_obt_data_params &p) const {
             string fioKey = p.fio_public_key;
-            fioio::replaceFormat(fioKey);
             FIO_400_ASSERT(fioio::isPubKeyValid(fioKey), "fio_public_key", p.fio_public_key.c_str(),
                            "Invalid FIO Public Key",
                            fioio::ErrorPubKeyValid);
@@ -2390,7 +2386,6 @@ if( options.count(name) ) { \
             // assert if empty chain key
             get_fio_names_result result;
             string fioKey = p.fio_public_key;
-            fioio::replaceFormat(fioKey);
 
             //first check the pub key for validity.
             FIO_400_ASSERT(fioio::isPubKeyValid(fioKey), "fio_public_key", p.fio_public_key.c_str(),
@@ -2657,7 +2652,6 @@ if( options.count(name) ) { \
 
         read_only::get_fio_balance_result read_only::get_fio_balance(const read_only::get_fio_balance_params &p) const {
             string fioKey = p.fio_public_key;
-            fioio::replaceFormat(fioKey);
             FIO_400_ASSERT(fioio::isPubKeyValid(fioKey), "fio_public_key", p.fio_public_key.c_str(),
                            "Invalid FIO Public Key",
                            fioio::ErrorPubKeyValid);


### PR DESCRIPTION
Since the PUB_K1 keys are hashed using the prefix, the changes that were implemented prior need to be reverted. 