### PR TITLE
Remove fee update from fee voting 

### DIFF
--- a/fio.contracts/contracts/fio.fee/fio.fee.cpp
+++ b/fio.contracts/contracts/fio.fee/fio.fee.cpp
@@ -250,7 +250,6 @@ namespace fioio {
                     fio_400_assert(false, "", "", "Too soon since last call", ErrorTimeViolation);
                 }
             }
-            update_fees();
 
             const string response_string = string("{\"status\": \"OK\"}");
 
@@ -392,8 +391,6 @@ namespace fioio {
                     f.lastvotetimestamp = nowtime;
                 });
             }
-
-            update_fees();
 
             const string response_string = string("{\"status\": \"OK\"}");
 


### PR DESCRIPTION
this PR removes updating of fees from fee voting actions, this should allow the BPs to get in over 15 votes and we can see if the fee computations on the block boundaries hold up with 21 votes.


If not we will need to consider extending the cpu limits of fio as the next short term iteration.