### PR TITLE
comment out the onblock running of fee computation.

### DIFF
--- a/fio.contracts/contracts/fio.system/src/producer_pay.cpp
+++ b/fio.contracts/contracts/fio.system/src/producer_pay.cpp
@@ -56,6 +56,7 @@ namespace eosiosystem {
 
         }
 
+        /* this needs testing, until tested we will remove it.
         if (timestamp.slot - _gstate.last_fee_update.slot > 126) {
 
           action(permission_level{get_self(), "active"_n},
@@ -66,6 +67,7 @@ namespace eosiosystem {
           _gstate.last_fee_update = timestamp;
 
         }
+         */
     }
 
     void system_contract::resetclaim(const name &producer) {


### PR DESCRIPTION
This PR will remove the computation of the fees from the unblock.
the fee computations need testing, and so its best to not have this untested code in such a critical area of the system.