### PR TITLE
example of using a table in state to replace action mapping in code.

### DIFF
--- a/fio.contracts/contracts/fio.common/fioerror.hpp
+++ b/fio.contracts/contracts/fio.common/fioerror.hpp
@@ -89,7 +89,7 @@ namespace fioio {
     constexpr auto ErrorTransactionTooLarge = ident | httpDataError | 152;   // Transaction too large
     constexpr auto ErrorRequestStatusInvalid = ident | httpDataError | 153;   // the specified request context record was not found
     constexpr auto ErrorActorIsSystemAccount = ident | httpDataError | 154;   // the specified actor is a FIO system account
-
+    constexpr auto ErrorNoFioActionsFound = ident | httpLocationError | 155;   // no actions found
     /**
     * Helper funtions for detecting rich error messages and extracting bitfielded values
     */

--- a/fio.contracts/contracts/fio.system/include/fio.system/native.hpp
+++ b/fio.contracts/contracts/fio.system/include/fio.system/native.hpp
@@ -120,6 +120,11 @@ namespace eosiosystem {
 
 
         [[eosio::action]]
+        void updateacts(const name &actionname,
+                        const string &contractname);
+
+
+        [[eosio::action]]
         void updateauth(const name &account,
                         const name &permission,
                         const name &parent,

--- a/fio.contracts/contracts/fio.system/include/fio.system/native.hpp
+++ b/fio.contracts/contracts/fio.system/include/fio.system/native.hpp
@@ -120,8 +120,13 @@ namespace eosiosystem {
 
 
         [[eosio::action]]
-        void updateacts(const name &actionname,
-                        const string &contractname);
+        void addaction(const name &action,
+                       const string &contract,
+                       const name &actor);
+
+        [[eosio::action]]
+        void remaction(const name &action,
+                       const name &actor);
 
 
         [[eosio::action]]

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -9,6 +9,7 @@
 #include <eosio/chain/authorization_manager.hpp>
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/account_object.hpp>
+#include <eosio/chain/fioaction_object.hpp>
 #include <eosio/chain/code_object.hpp>
 #include <eosio/chain/global_property_object.hpp>
 #include <boost/container/flat_set.hpp>

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -52,13 +52,20 @@ namespace eosio {
 
             const auto &cfg = control.get_global_properties().configuration;
             const account_metadata_object *receiver_account = nullptr;
+            const account_metadata_object *receiver_tmp = nullptr;
+            const fioaction_object *fioaction_item = nullptr;
+
             try {
                 try {
                     receiver_account = &db.get<account_metadata_object, by_name>(receiver);
+                    action_name  thename = act->name;
+
+
+                    fioaction_item = db.find<fioaction_object, by_actionname>(thename);
                     privileged = receiver_account->is_privileged();
                     auto native = control.find_apply_handler(receiver, act->account, act->name);
                     if (act->name != name("nonce")){
-                      EOS_ASSERT(act->account.to_string() == fioio::map_to_contract(act->name.to_string()), action_validate_exception,
+                      EOS_ASSERT(fioaction_item != nullptr, action_validate_exception,
                                  "Unknown action ${action} in contract ${contract}",
                                  ("action", act->name)("contract", act->account));
                       EOS_ASSERT(sizeof(act->data) < config::max_transaction_size, action_validate_exception,

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -6,6 +6,7 @@
 #include <eosio/chain/exceptions.hpp>
 
 #include <eosio/chain/account_object.hpp>
+#include <eosio/chain/fioaction_object.hpp>
 #include <eosio/chain/code_object.hpp>
 #include <eosio/chain/block_summary_object.hpp>
 #include <eosio/chain/eosio_contract.hpp>

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -46,7 +46,8 @@ namespace eosio {
                 transaction_multi_index,
                 generated_transaction_multi_index,
                 table_id_multi_index,
-                code_index
+                code_index,
+                fioaction_index
         >;
 
         using contract_database_index_set = index_set<
@@ -344,6 +345,7 @@ namespace eosio {
                 SET_APP_HANDLER(eosio, eosio, deleteauth);
                 SET_APP_HANDLER(eosio, eosio, linkauth);
                 SET_APP_HANDLER(eosio, eosio, unlinkauth);
+                SET_APP_HANDLER(eosio, eosio, updateacts);
 /*
    SET_APP_HANDLER( eosio, eosio, postrecovery );
    SET_APP_HANDLER( eosio, eosio, passrecovery );
@@ -1008,6 +1010,8 @@ namespace eosio {
 
                 db.create<dynamic_global_property_object>([](auto &) {});
 
+                db.create<fioaction_object>([](auto &) {}); /// reserve perm 0 (used else where)
+
                 authorization.initialize_database();
                 resource_limits.initialize_database();
 
@@ -1032,6 +1036,476 @@ namespace eosio {
                                                                                   majority_permission.id,
                                                                                   active_producers_authority,
                                                                                   conf.genesis.initial_timestamp);
+
+                const auto &ins1 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(approve);
+                    a.contractname = "eosio.msig";
+                    a.blocktimestamp = 1;
+                });
+
+                const auto &ins2 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(unapprove);
+                    a.contractname = "eosio.msig";
+                    a.blocktimestamp = 1;
+                });
+
+                const auto &ins3 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(propose);
+                    a.contractname = "eosio.msig";
+                    a.blocktimestamp = 1;
+                });
+
+                const auto &ins4 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(exec);
+                    a.contractname = "eosio.msig";
+                    a.blocktimestamp = 1;
+                });
+
+                const auto &ins5 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(invalidate);
+                    a.contractname = "eosio.msig";
+                    a.blocktimestamp = 1;
+                });
+
+                const auto &ins6 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(cancel);
+                    a.contractname = "fio.address";
+                    a.blocktimestamp = 1;
+                });
+
+
+              //  if (action == "regaddress" || action == "regdomain" || action == "addaddress" ||
+              const auto &ins7 = db.create<fioaction_object>([&](auto &a) {
+                        a.actionname = N(regaddress);
+                        a.contractname = "fio.address";
+                        a.blocktimestamp = 1;
+                    });
+                const auto &ins8 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(regdomain);
+                    a.contractname = "fio.address";
+                    a.blocktimestamp = 1;
+                });
+                const auto &ins9 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(addaddress);
+                    a.contractname = "fio.address";
+                    a.blocktimestamp = 1;
+                });
+                //    action == "remaddress" || action == "remalladdr" ||
+                const auto &ins10 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(remaddress);
+                    a.contractname = "fio.address";
+                    a.blocktimestamp = 1;
+                });
+                const auto &ins11 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(remalladdr);
+                    a.contractname = "fio.address";
+                    a.blocktimestamp = 1;
+                });
+                 //   action == "renewdomain" || action == "renewaddress" ||
+                const auto &ins12 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(renewdomain);
+                    a.contractname = "fio.address";
+                    a.blocktimestamp = 1;
+                });
+                const auto &ins13 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(renewaddress);
+                    a.contractname = "fio.address";
+                    a.blocktimestamp = 1;
+                });
+                //    action == "setdomainpub" || action == "bind2eosio" ||
+                const auto &ins14 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(setdomainpub);
+                    a.contractname = "fio.address";
+                    a.blocktimestamp = 1;
+                });
+                const auto &ins15 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(bind2eosio);
+                    a.contractname = "fio.address";
+                    a.blocktimestamp = 1;
+                });
+                //    action == "burnexpired" || action == "decrcounter" || action == "xferdomain" || action == "xferaddress" )
+                const auto &ins16 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(burnexpired);
+                    a.contractname = "fio.address";
+                    a.blocktimestamp = 1;
+                });
+                const auto &ins17 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(decrcounter);
+                    a.contractname = "fio.address";
+                    a.blocktimestamp = 1;
+                });
+                const auto &ins18 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(xferdomain);
+                    a.contractname = "fio.address";
+                    a.blocktimestamp = 1;
+                });
+                const auto &ins19 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(xferaddress);
+                    a.contractname = "fio.address";
+                    a.blocktimestamp = 1;
+                });
+
+
+
+        // fio.fee actions
+        //if (action == "setfeemult" || action == "bundlevote" || action == "setfeevote" ||
+                const auto &fee1 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(setfeemult);
+                    a.contractname = "fio.fee";
+                    a.blocktimestamp = 1;
+                });
+                const auto &fee2 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(bundlevote);
+                    a.contractname = "fio.fee";
+                    a.blocktimestamp = 1;
+                });
+                const auto &fee3 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(setfeevote);
+                    a.contractname = "fio.fee";
+                    a.blocktimestamp = 1;
+                });
+           // action == "bytemandfee" || action == "updatefees" || action == "mandatoryfee" ||
+                const auto &fee4 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(bytemandfee);
+                    a.contractname = "fio.fee";
+                    a.blocktimestamp = 1;
+                });
+                const auto &fee5 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(updatefees);
+                    a.contractname = "fio.fee";
+                    a.blocktimestamp = 1;
+                });
+                const auto &fee6 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(mandatoryfee);
+                    a.contractname = "fio.fee";
+                    a.blocktimestamp = 1;
+                });
+           // action == "createfee")
+                const auto &fee7 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(createfee);
+                    a.contractname = "fio.fee";
+                    a.blocktimestamp = 1;
+                });
+
+
+                // fio.treasury actions
+               // if (action == "tpidclaim" || action == "bpclaim" || action == "bppoolupdate" ||
+                const auto &treas1 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(tpidclaim);
+                    a.contractname = "fio.treasury";
+                    a.blocktimestamp = 1;
+                });
+                const auto &treas2 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(bpclaim);
+                    a.contractname = "fio.treasury";
+                    a.blocktimestamp = 1;
+                });
+                const auto &treas3 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(bppoolupdate);
+                    a.contractname = "fio.treasury";
+                    a.blocktimestamp = 1;
+                });
+               //     action == "fdtnrwdupdat" || action == "bprewdupdate" || action == "startclock" ||
+                const auto &treas4 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(fdtnrwdupdat);
+                    a.contractname = "fio.treasury";
+                    a.blocktimestamp = 1;
+                });
+                const auto &treas5 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(bprewdupdate);
+                    a.contractname = "fio.treasury";
+                    a.blocktimestamp = 1;
+                });
+                const auto &treas6 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(startclock);
+                    a.contractname = "fio.treasury";
+                    a.blocktimestamp = 1;
+                });
+                 //   action == "updateclock")
+                const auto &treas7 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(updateclock);
+                    a.contractname = "fio.treasury";
+                    a.blocktimestamp = 1;
+                });
+
+
+
+
+
+
+        //fio.token actions
+       // if (action == "trnsfiopubky" || action == "create" || action == "issue" ||
+                const auto &tok1 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(trnsfiopubky);
+                    a.contractname = "fio.token";
+                    a.blocktimestamp = 1;
+                });
+                const auto &tok2 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(create);
+                    a.contractname = "fio.token";
+                    a.blocktimestamp = 1;
+                });
+                const auto &tok3 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(issue);
+                    a.contractname = "fio.token";
+                    a.blocktimestamp = 1;
+                });
+                //     action == "transfer" || action == "mintfio")
+                const auto &tok4 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(transfer);
+                    a.contractname = "fio.token";
+                    a.blocktimestamp = 1;
+                });
+                const auto &tok5 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(mintfio);
+                    a.contractname = "fio.token";
+                    a.blocktimestamp = 1;
+                });
+       //   return "fio.token";
+        //fio.request.obt actions
+      //  if (action == "recordobt" || action == "rejectfndreq" || action == "cancelfndreq"  || action == "newfundsreq")
+                const auto &req1 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(recordobt);
+                    a.contractname = "fio.reqobt";
+                    a.blocktimestamp = 1;
+                });
+                const auto &req2 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(rejectfndreq);
+                    a.contractname = "fio.reqobt";
+                    a.blocktimestamp = 1;
+                });
+                const auto &req3 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(cancelfndreq);
+                    a.contractname = "fio.reqobt";
+                    a.blocktimestamp = 1;
+                });
+                const auto &req4 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(newfundsreq);
+                    a.contractname = "fio.reqobt";
+                    a.blocktimestamp = 1;
+                });
+      //    return "fio.reqobt";
+
+        //fio.tpid actions
+      //  if (action == "updatebounty" || action == "rewardspaid" || action == "updatetpid")
+                const auto &tpid1 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(updatebounty);
+                    a.contractname = "fio.tpid";
+                    a.blocktimestamp = 1;
+                });
+                const auto &tpid2 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(rewardspaid);
+                    a.contractname = "fio.tpid";
+                    a.blocktimestamp = 1;
+                });
+                const auto &tpid3 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(updatetpid);
+                    a.contractname = "fio.tpid";
+                    a.blocktimestamp = 1;
+                });
+       //   return "fio.tpid";
+
+        // eosio.wrap actions
+      //  if (action == "execute")
+                const auto &exe1 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(execute);
+                    a.contractname = "eosio.wrap";
+                    a.blocktimestamp = 1;
+                });
+       //   return "eosio.wrap";
+
+
+        //system actions
+     //   if (action == "newaccount" || action == "onblock" || action == "addlocked" ||
+                const auto &eos1 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(newaccount);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos2 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(onblock);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos3 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(addlocked);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+     //       action == "regproducer" || action == "unregprod" || action == "regproxy" ||
+                const auto &eos4 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(regproducer);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos5 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(unregprod);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos6 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(regproxy);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+     //       action == "voteproducer" || action == "unregproxy" || action == "voteproxy" ||
+                const auto &eos7 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(voteproducer);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos8 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(unregproxy);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos9 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(voteproxy);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+     //       action == "setabi" || action == "setcode" || action == "updateauth" ||
+                const auto &eos10 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(setabi);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos11 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(setcode);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos12 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(updateauth);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+     //       action == "setprods" || action == "setpriv" || action == "init" ||
+                const auto &eos13 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(setprods);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos14 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(setpriv);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos15 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(init);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+     //       action == "nonce" || action == "burnaction" || action == "canceldelay" ||
+                const auto &eos16 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(nonce);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos17 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(burnaction);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos18 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(canceldelay);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+     //       action == "crautoproxy" || action == "deleteauth" || action == "inhibitunlck" ||
+                const auto &eos19 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(crautoproxy);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos20 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(deleteauth);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos21 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(inhibitunlck);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+     //       action == "linkauth" || action == "onerror" || action == "unlinkauth" ||
+                const auto &eos22 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(linkauth);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos23 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(onerror);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos24 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(unlinkauth);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+     //       action == "rmvproducer" || action == "setautoproxy" || action == "setparams" ||
+                const auto &eos25 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(rmvproducer);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos26 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(setautoproxy);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos27 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(setparams);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+     //       action == "unlocktokens" || action == "updtrevision" ||action == "updlocked" ||
+                const auto &eos28 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(unlocktokens);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos29 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(updtrevision);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos30 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(updlocked);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+     //       action == "updatepower" ||
+                const auto &eos31 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(updatepower);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+     //       action == "updlbpclaim" || action == "resetclaim" || action == "incram" || action == "updateacts")
+                const auto &eos32 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(updlbpclaim);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos33 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(resetclaim);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos34 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(incram);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos35 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(updateacts);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+     //     return "eosio";
+
+
             }
 
             // The returned scoped_exit should not exceed the lifetime of the pending which existed when make_block_restore_point was called.

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -345,7 +345,8 @@ namespace eosio {
                 SET_APP_HANDLER(eosio, eosio, deleteauth);
                 SET_APP_HANDLER(eosio, eosio, linkauth);
                 SET_APP_HANDLER(eosio, eosio, unlinkauth);
-                SET_APP_HANDLER(eosio, eosio, updateacts);
+                SET_APP_HANDLER(eosio, eosio, addaction);
+                SET_APP_HANDLER(eosio, eosio, remaction);
 /*
    SET_APP_HANDLER( eosio, eosio, postrecovery );
    SET_APP_HANDLER( eosio, eosio, passrecovery );
@@ -1482,7 +1483,7 @@ namespace eosio {
                     a.contractname = "eosio";
                     a.blocktimestamp = 1;
                 });
-     //       action == "updlbpclaim" || action == "resetclaim" || action == "incram" || action == "updateacts")
+     //       action == "updlbpclaim" || action == "resetclaim" || action == "incram" || action == "addaction")
                 const auto &eos32 = db.create<fioaction_object>([&](auto &a) {
                     a.actionname = N(updlbpclaim);
                     a.contractname = "eosio";
@@ -1499,7 +1500,12 @@ namespace eosio {
                     a.blocktimestamp = 1;
                 });
                 const auto &eos35 = db.create<fioaction_object>([&](auto &a) {
-                    a.actionname = N(updateacts);
+                    a.actionname = N(addaction);
+                    a.contractname = "eosio";
+                    a.blocktimestamp = 1;
+                });
+                const auto &eos36 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(remaction);
                     a.contractname = "eosio";
                     a.blocktimestamp = 1;
                 });

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1012,8 +1012,6 @@ namespace eosio {
 
                 db.create<dynamic_global_property_object>([](auto &) {});
 
-                db.create<fioaction_object>([](auto &) {}); /// reserve perm 0 (used else where)
-
                 authorization.initialize_database();
                 resource_limits.initialize_database();
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1036,6 +1036,7 @@ namespace eosio {
                                                                                   majority_permission.id,
                                                                                   active_producers_authority,
                                                                                   conf.genesis.initial_timestamp);
+                /*
 
                 const auto &ins1 = db.create<fioaction_object>([&](auto &a) {
                     a.actionname = N(approve);
@@ -1509,6 +1510,7 @@ namespace eosio {
                     a.blocktimestamp = 1;
                 });
      //     return "eosio";
+                 */
 
 
             }

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -12,6 +12,7 @@
 #include <eosio/chain/exceptions.hpp>
 
 #include <eosio/chain/account_object.hpp>
+#include <eosio/chain/fioaction_object.hpp>
 #include <eosio/chain/code_object.hpp>
 #include <eosio/chain/permission_object.hpp>
 #include <eosio/chain/permission_link_object.hpp>

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -89,23 +89,22 @@ namespace eosio {
                            create.actor == TREASURYACCOUNT ||
                            create.actor == FIOSYSTEMACCOUNT ||
                            create.actor == FIOACCOUNT
-                        ,fio_invalid_account_or_action,"addaction not permitted." );
+                        ,fio_invalid_account_or_action,"Invalid Signature" );
 
 
                 auto &db = context.db;
 
                 auto name_str = name(create.action).to_string();
 
-                EOS_ASSERT(!create.action.empty(), action_validate_exception, "action name cannot be empty");
-                EOS_ASSERT(name_str.size() <= 12, action_validate_exception, "action names can only be 12 chars long");
-                EOS_ASSERT(!create.actor.empty(), action_validate_exception, "actor name cannot be empty");
-                EOS_ASSERT(!create.contract.empty(), action_validate_exception, "action name cannot be empty");
+                EOS_ASSERT(!create.action.empty(), action_validate_exception, "Action invalid or not found");
+                EOS_ASSERT(name_str.size() <= 12, action_validate_exception, "Action invalid or not found");
+                EOS_ASSERT(!create.actor.empty(), action_validate_exception, "Invalid Signature");
+                EOS_ASSERT(!create.contract.empty(), action_validate_exception, "Invalid Contract");
 
 
                 auto fioaction_name = db.find<fioaction_object, by_actionname>(create.action);
                 EOS_ASSERT(fioaction_name == nullptr, account_name_exists_exception,
-                           "Cannot add action named ${name}, as that name is already taken",
-                           ("name", create.action));
+                           "Action invalid or not found");
 
 
                 const auto &new_fioaction = db.create<fioaction_object>([&](auto &a) {
@@ -138,21 +137,20 @@ namespace eosio {
                            rem.actor == TREASURYACCOUNT ||
                            rem.actor == FIOSYSTEMACCOUNT ||
                            rem.actor == FIOACCOUNT
-                        ,fio_invalid_account_or_action,"addaction not permitted." );
+                        ,fio_invalid_account_or_action,"Invalid Signature" );
 
 
                 auto &db = context.db;
 
                 auto name_str = name(rem.action).to_string();
 
-                EOS_ASSERT(!rem.action.empty(), action_validate_exception, "action name cannot be empty");
-                EOS_ASSERT(name_str.size() <= 12, action_validate_exception, "action names can only be 12 chars long");
-                EOS_ASSERT(!rem.actor.empty(), action_validate_exception, "actor name cannot be empty");
+                EOS_ASSERT(!rem.action.empty(), action_validate_exception, "Action invalid or not found");
+                EOS_ASSERT(name_str.size() <= 12, action_validate_exception, "Action invalid or not found");
+                EOS_ASSERT(!rem.actor.empty(), action_validate_exception, "Invalid Signature");
 
                 auto fioaction_name = db.find<fioaction_object, by_actionname>(rem.action);
                 EOS_ASSERT(fioaction_name != nullptr, account_name_exists_exception,
-                           "Cannot remove action named ${name}, the name does not exist",
-                           ("name", rem.action));
+                           "Action invalid or not found");
 
 
                 db.remove(*fioaction_name);

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -66,7 +66,46 @@ namespace eosio {
             }
         }
 
-/**
+        /**
+         *  This method is called assuming precondition_system_newaccount succeeds a
+         */
+        void apply_eosio_updateacts(apply_context &context) {
+            auto create = context.get_action().data_as<updateacts>();
+            try {
+               // context.require_authorization(create.creator);
+
+               // auto &authorization = context.control.get_mutable_authorization_manager();
+
+               // EOS_ASSERT(validate(create.owner), action_validate_exception, "Invalid owner authority");
+               // EOS_ASSERT(validate(create.active), action_validate_exception, "Invalid active authority");
+
+                auto &db = context.db;
+
+                auto name_str = name(create.actionname).to_string();
+
+                EOS_ASSERT(!create.actionname.empty(), action_validate_exception, "account name cannot be empty");
+                EOS_ASSERT(name_str.size() <= 12, action_validate_exception, "account names can only be 12 chars long");
+
+
+                std::cout << "EDEDEDEDEDEDED before the first find ";
+                auto fioaction_name = db.find<fioaction_object, by_actionname>(create.actionname);
+                EOS_ASSERT(fioaction_name == nullptr, account_name_exists_exception,
+                           "Cannot create account named ${name}, as that name is already taken",
+                           ("name", create.actionname));
+                std::cout << "EDEDEDEDEDEDED after the first find ";
+
+                const auto &new_fioaction = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = create.actionname;
+                    a.contractname = create.contractname;
+                    a.blocktimestamp = context.control.pending_block_time().time_since_epoch().count();
+                });
+                std::cout << "EDEDEDEDEDEDED after the create!! ";
+
+            } FC_CAPTURE_AND_RETHROW((create))
+        }
+
+
+        /**
  *  This method is called assuming precondition_system_newaccount succeeds a
  */
         void apply_eosio_newaccount(apply_context &context) {

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -148,9 +148,17 @@ namespace eosio {
             });
 
             eos_abi.structs.emplace_back(struct_def{
-                    "updateacts", "", {
-                            {"name", "actionname"},
-                            {"string", "contractname"}
+                    "addaction", "", {
+                            {"name", "action"},
+                            {"string", "contract"},
+                            {"name","actor"}
+                    }
+            });
+
+            eos_abi.structs.emplace_back(struct_def{
+                    "remaction", "", {
+                            {"name", "action"},
+                            {"name","actor"}
                     }
             });
 
@@ -234,7 +242,8 @@ namespace eosio {
             eos_abi.actions.push_back(action_def{name("canceldelay"), "canceldelay", ""});
             eos_abi.actions.push_back(action_def{name("onerror"), "onerror", ""});
             eos_abi.actions.push_back(action_def{name("onblock"), "onblock", ""});
-            eos_abi.actions.push_back(action_def{name("updateacts"), "updateacts", ""});
+            eos_abi.actions.push_back(action_def{name("addaction"), "addaction", ""});
+            eos_abi.actions.push_back(action_def{name("remaction"), "remaction", ""});
 
             return eos_abi;
         }

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -86,6 +86,8 @@ namespace eosio {
                     }
             });
 
+
+
             eos_abi.structs.emplace_back(struct_def{
                     "block_header", "", {
                             {"timestamp", "uint32"},
@@ -131,6 +133,7 @@ namespace eosio {
                     }
             });
 
+
             // TODO add any ricardian_clauses
             //
             // ACTION PAYLOADS
@@ -141,6 +144,13 @@ namespace eosio {
                             {"name", "account_name"},
                             {"owner", "authority"},
                             {"active", "authority"},
+                    }
+            });
+
+            eos_abi.structs.emplace_back(struct_def{
+                    "updateacts", "", {
+                            {"name", "actionname"},
+                            {"string", "contractname"}
                     }
             });
 
@@ -224,6 +234,7 @@ namespace eosio {
             eos_abi.actions.push_back(action_def{name("canceldelay"), "canceldelay", ""});
             eos_abi.actions.push_back(action_def{name("onerror"), "onerror", ""});
             eos_abi.actions.push_back(action_def{name("onblock"), "onblock", ""});
+            eos_abi.actions.push_back(action_def{name("updateacts"), "updateacts", ""});
 
             return eos_abi;
         }

--- a/libraries/chain/include/eosio/chain/account_object.hpp
+++ b/libraries/chain/include/eosio/chain/account_object.hpp
@@ -104,37 +104,15 @@ namespace eosio {
                 >
         >;
 
-        class fioaction_object : public chainbase::object<fioaction_object_type, fioaction_object> {
-            OBJECT_CTOR(fioaction_object)
-
-            id_type id;
-            action_name actionname; //< name should not be changed within a chainbase modifier lambda
-            string contractname;
-            uint64_t blocktimestamp;
-        };
-
-        using fioaction_id_type = fioaction_object::id_type;
-
-        struct by_actionname;
-        using fioaction_index = chainbase::shared_multi_index_container<
-        fioaction_object,
-        indexed_by<
-                ordered_unique<tag<by_id>, member<fioaction_object, fioaction_object::id_type, &fioaction_object::id>>,
-        ordered_unique<tag<by_actionname>, member<fioaction_object, action_name, &fioaction_object::actionname>>
-        >
-        >;
-
     }
 } // eosio::chain
 
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::account_object, eosio::chain::account_index)
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::account_metadata_object, eosio::chain::account_metadata_index)
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::account_ram_correction_object, eosio::chain::account_ram_correction_index)
-CHAINBASE_SET_INDEX_TYPE(eosio::chain::fioaction_object, eosio::chain::fioaction_index)
 
 
 FC_REFLECT(eosio::chain::account_object, (name)(creation_date)(abi))
 FC_REFLECT(eosio::chain::account_metadata_object, (name)(recv_sequence)(auth_sequence)(code_sequence)(abi_sequence)
         (code_hash)(last_code_update)(flags)(vm_type)(vm_version))
 FC_REFLECT(eosio::chain::account_ram_correction_object, (name)(ram_correction))
-FC_REFLECT(eosio::chain::fioaction_object, (actionname)(contractname)(blocktimestamp))

--- a/libraries/chain/include/eosio/chain/account_object.hpp
+++ b/libraries/chain/include/eosio/chain/account_object.hpp
@@ -104,15 +104,37 @@ namespace eosio {
                 >
         >;
 
+        class fioaction_object : public chainbase::object<fioaction_object_type, fioaction_object> {
+            OBJECT_CTOR(fioaction_object)
+
+            id_type id;
+            action_name actionname; //< name should not be changed within a chainbase modifier lambda
+            string contractname;
+            uint64_t blocktimestamp;
+        };
+
+        using fioaction_id_type = fioaction_object::id_type;
+
+        struct by_actionname;
+        using fioaction_index = chainbase::shared_multi_index_container<
+        fioaction_object,
+        indexed_by<
+                ordered_unique<tag<by_id>, member<fioaction_object, fioaction_object::id_type, &fioaction_object::id>>,
+        ordered_unique<tag<by_actionname>, member<fioaction_object, action_name, &fioaction_object::actionname>>
+        >
+        >;
+
     }
 } // eosio::chain
 
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::account_object, eosio::chain::account_index)
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::account_metadata_object, eosio::chain::account_metadata_index)
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::account_ram_correction_object, eosio::chain::account_ram_correction_index)
+CHAINBASE_SET_INDEX_TYPE(eosio::chain::fioaction_object, eosio::chain::fioaction_index)
 
 
 FC_REFLECT(eosio::chain::account_object, (name)(creation_date)(abi))
 FC_REFLECT(eosio::chain::account_metadata_object, (name)(recv_sequence)(auth_sequence)(code_sequence)(abi_sequence)
         (code_hash)(last_code_update)(flags)(vm_type)(vm_version))
 FC_REFLECT(eosio::chain::account_ram_correction_object, (name)(ram_correction))
+FC_REFLECT(eosio::chain::fioaction_object, (actionname)(contractname)(blocktimestamp))

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -12,7 +12,6 @@
 #include <algorithm>
 #include <set>
 
-namespace chainbase { class database; }
 
 namespace eosio {
     namespace chain {

--- a/libraries/chain/include/eosio/chain/contract_types.hpp
+++ b/libraries/chain/include/eosio/chain/contract_types.hpp
@@ -25,17 +25,30 @@ namespace eosio {
             }
         };
 
-        struct updateacts {
-            name actionname;
-            string contractname;
-
+        struct addaction {
+            name action;
+            string contract;
+            name actor;
 
             static account_name get_account() {
                 return config::system_account_name;
             }
 
             static action_name get_name() {
-                return N(updateacts);
+                return N(addaction);
+            }
+        };
+
+        struct remaction {
+            name action;
+            name actor;
+
+            static account_name get_account() {
+                return config::system_account_name;
+            }
+
+            static action_name get_name() {
+                return N(remaction);
             }
         };
 
@@ -258,7 +271,8 @@ namespace eosio {
 } /// namespace eosio::chain
 
 FC_REFLECT(eosio::chain::newaccount, (creator)(name)(owner)(active))
-FC_REFLECT(eosio::chain::updateacts, (actionname)(contractname))
+FC_REFLECT(eosio::chain::addaction, (action)(contract)(actor))
+FC_REFLECT(eosio::chain::remaction, (action)(actor))
 FC_REFLECT(eosio::chain::setcode, (account)(vmtype)(vmversion)(code))
 FC_REFLECT(eosio::chain::setabi, (account)(abi))
 FC_REFLECT(eosio::chain::updateauth, (account)(permission)(parent)(auth)(max_fee))

--- a/libraries/chain/include/eosio/chain/contract_types.hpp
+++ b/libraries/chain/include/eosio/chain/contract_types.hpp
@@ -25,6 +25,20 @@ namespace eosio {
             }
         };
 
+        struct updateacts {
+            name actionname;
+            string contractname;
+
+
+            static account_name get_account() {
+                return config::system_account_name;
+            }
+
+            static action_name get_name() {
+                return N(updateacts);
+            }
+        };
+
         struct trnsfiopubky {
             string payee_public_key;
             int64_t amount;
@@ -244,6 +258,7 @@ namespace eosio {
 } /// namespace eosio::chain
 
 FC_REFLECT(eosio::chain::newaccount, (creator)(name)(owner)(active))
+FC_REFLECT(eosio::chain::updateacts, (actionname)(contractname))
 FC_REFLECT(eosio::chain::setcode, (account)(vmtype)(vmversion)(code))
 FC_REFLECT(eosio::chain::setabi, (account)(abi))
 FC_REFLECT(eosio::chain::updateauth, (account)(permission)(parent)(auth)(max_fee))

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -42,6 +42,8 @@ namespace eosio {
 
         class account_object;
 
+        class fioaction_object;
+
         using resource_limits::resource_limits_manager;
         using apply_handler = std::function<void(apply_context &)>;
         using unapplied_transactions_type = map<transaction_id_type, transaction_metadata_ptr, sha256_less>;

--- a/libraries/chain/include/eosio/chain/eosio_contract.hpp
+++ b/libraries/chain/include/eosio/chain/eosio_contract.hpp
@@ -52,7 +52,9 @@ namespace eosio {
 
         void apply_eosio_unlinkauth(apply_context &);
 
-        void apply_eosio_updateacts(apply_context &);
+        void apply_eosio_addaction(apply_context &);
+
+        void apply_eosio_remaction(apply_context &);
 
         /*
         void apply_eosio_postrecovery(apply_context&);

--- a/libraries/chain/include/eosio/chain/eosio_contract.hpp
+++ b/libraries/chain/include/eosio/chain/eosio_contract.hpp
@@ -52,6 +52,8 @@ namespace eosio {
 
         void apply_eosio_unlinkauth(apply_context &);
 
+        void apply_eosio_updateacts(apply_context &);
+
         /*
         void apply_eosio_postrecovery(apply_context&);
         void apply_eosio_passrecovery(apply_context&);

--- a/libraries/chain/include/eosio/chain/fioaction_object.hpp
+++ b/libraries/chain/include/eosio/chain/fioaction_object.hpp
@@ -1,0 +1,46 @@
+/**
+ *  @file
+ *  @copyright defined in fio/LICENSE
+ */
+#pragma once
+
+#include <eosio/chain/database_utils.hpp>
+#include <eosio/chain/authority.hpp>
+#include <eosio/chain/code_object.hpp>
+#include <eosio/chain/block_timestamp.hpp>
+#include <eosio/chain/abi_def.hpp>
+
+#include "multi_index_includes.hpp"
+
+namespace eosio {
+    namespace chain {
+
+
+        class fioaction_object : public chainbase::object<fioaction_object_type, fioaction_object> {
+            OBJECT_CTOR(fioaction_object)
+
+            id_type id;
+            action_name actionname; //< name should not be changed within a chainbase modifier lambda
+            string contractname;
+            uint64_t blocktimestamp;
+        };
+
+        using fioaction_id_type = fioaction_object::id_type;
+
+        struct by_actionname;
+        using fioaction_index = chainbase::shared_multi_index_container<
+        fioaction_object,
+        indexed_by<
+                ordered_unique<tag<by_id>, member<fioaction_object, fioaction_object::id_type, &fioaction_object::id>>,
+        ordered_unique<tag<by_actionname>, member<fioaction_object, action_name, &fioaction_object::actionname>>
+        >
+        >;
+
+    }
+} // eosio::chain
+
+
+CHAINBASE_SET_INDEX_TYPE(eosio::chain::fioaction_object, eosio::chain::fioaction_index)
+
+
+FC_REFLECT(eosio::chain::fioaction_object, (actionname)(contractname)(blocktimestamp))

--- a/libraries/chain/include/eosio/chain/fioio/actionmapping.hpp
+++ b/libraries/chain/include/eosio/chain/fioio/actionmapping.hpp
@@ -71,7 +71,8 @@ namespace fioio {
             action == "rmvproducer" || action == "setautoproxy" || action == "setparams" ||
             action == "unlocktokens" || action == "updtrevision" ||action == "updlocked" ||
             action == "updatepower" ||
-            action == "updlbpclaim" || action == "resetclaim" || action == "incram" || action == "updateacts")
+            action == "updlbpclaim" || action == "resetclaim" || action == "incram" ||
+            action == "addaction" || action == "remaction")
           return "eosio";
 
         if (action == "nonce")

--- a/libraries/chain/include/eosio/chain/fioio/actionmapping.hpp
+++ b/libraries/chain/include/eosio/chain/fioio/actionmapping.hpp
@@ -71,7 +71,7 @@ namespace fioio {
             action == "rmvproducer" || action == "setautoproxy" || action == "setparams" ||
             action == "unlocktokens" || action == "updtrevision" ||action == "updlocked" ||
             action == "updatepower" ||
-            action == "updlbpclaim" || action == "resetclaim" || action == "incram")
+            action == "updlbpclaim" || action == "resetclaim" || action == "incram" || action == "updateacts")
           return "eosio";
 
         if (action == "nonce")

--- a/libraries/chain/include/eosio/chain/types.hpp
+++ b/libraries/chain/include/eosio/chain/types.hpp
@@ -192,6 +192,7 @@ namespace eosio {
             protocol_state_object_type,
             account_ram_correction_object_type,
             code_object_type,
+            fioaction_object_type,
             OBJECT_TYPE_COUNT ///< Sentry value which contains the number of different object types
         };
 
@@ -243,6 +244,7 @@ namespace eosio {
          */
 
         class account_object;
+        class fioaction_object;
 
         using block_id_type       = fc::sha256;
         using checksum_type       = fc::sha256;

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -112,6 +112,7 @@ namespace eosio {
                                      CHAIN_RO_CALL(get_fio_domains, 200),
                                      CHAIN_RO_CALL(get_fio_addresses, 200),
                                      CHAIN_RO_CALL(get_fee, 200),
+                                     CHAIN_RO_CALL(get_actions, 200),
                                      CHAIN_RO_CALL(avail_check, 200),
                                      CHAIN_RO_CALL(serialize_json, 200),
                                      CHAIN_RO_CALL(get_pub_address, 200),

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -5502,13 +5502,20 @@ if( options.count(name) ) { \
         read_only::serialize_json(const read_only::serialize_json_params &params) const try {
             serialize_json_result result;
 
-            const fioaction_object *fioaction_item = nullptr;
-            action_name nm = params.action;
-            fioaction_item = db.db().find<fioaction_object,by_actionname>(nm);
-            EOS_ASSERT(fioaction_item != nullptr, contract_query_exception, "Action can't be found ${contract}",
-                       ("contract", params.action.to_string()));
+            const int32_t HF1_BLOCK_TIME = 1594336300; //july 9 2020
+            string actionname;
 
-            string actionname = fioaction_item->contractname;
+            action_name nm = params.action;
+            if ( db.head_block_time().sec_since_epoch() > HF1_BLOCK_TIME) {
+                const fioaction_object *fioaction_item = nullptr;
+                fioaction_item = db.db().find<fioaction_object, by_actionname>(nm);
+                EOS_ASSERT(fioaction_item != nullptr, contract_query_exception, "Action can't be found ${contract}",
+                           ("contract", params.action.to_string()));
+                actionname = fioaction_item->contractname;
+            }else{
+                actionname = fioio::map_to_contract(params.action.to_string());
+            }
+
             name code = ::eosio::string_to_name(actionname.c_str());
 
             const auto code_account = db.db().find<account_object, by_name>(code);

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -7,6 +7,7 @@
 #include <eosio/chain/fork_database.hpp>
 #include <eosio/chain/block_log.hpp>
 #include <eosio/chain/exceptions.hpp>
+#include <eosio/chain/fioaction_object.hpp>
 #include <eosio/chain/authorization_manager.hpp>
 #include <eosio/chain/code_object.hpp>
 #include <eosio/chain/config.hpp>
@@ -1798,6 +1799,57 @@ if( options.count(name) ) { \
             result.more = search_results;
             return result;
         } // get_pending_fio_requests
+
+
+
+        read_only::get_actions_result
+        read_only::get_actions(const read_only::get_actions_params &p) const {
+
+            FIO_400_ASSERT(p.limit >= 0, "limit", to_string(p.limit), "Invalid limit",
+                           fioio::ErrorPagingInvalid);
+
+            FIO_400_ASSERT(p.offset >= 0, "offset", to_string(p.offset), "Invalid offset",
+                           fioio::ErrorPagingInvalid);
+
+            get_actions_result results;
+
+            const auto &idx = db.db().get_index<fioaction_index,by_id>();
+            auto itr = idx.rbegin();
+
+            int count = 0;
+            if (p.offset > 0){
+                while ((itr != idx.rend()) && (count < p.offset)){
+                    itr++;
+                    count++;
+                }
+            }
+
+            count = 0;
+            while ((itr != idx.rend())){
+                if (count == p.limit && p.limit != 0){
+                    break;
+                }
+                string action = itr->actionname.to_string();
+                string contract = itr->contractname;
+                string timestamp = to_string(itr->blocktimestamp);
+
+                action_record rr{action, contract, timestamp};
+                results.actions.push_back(rr);
+                itr++;
+                count++;
+            }
+
+            count = 0;
+            while ((itr != idx.rend())){
+                itr++;
+                count++;
+            }
+
+
+            FIO_404_ASSERT(!(results.actions.size() == 0), "No actions", fioio::ErrorNoFioActionsFound);
+            results.more = count;
+            return results;
+        } // get_actions
 
 
         /***

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -5450,7 +5450,13 @@ if( options.count(name) ) { \
         read_only::serialize_json(const read_only::serialize_json_params &params) const try {
             serialize_json_result result;
 
-            string actionname = fioio::map_to_contract(params.action.to_string());
+            const fioaction_object *fioaction_item = nullptr;
+            action_name nm = params.action;
+            fioaction_item = db.db().find<fioaction_object,by_actionname>(nm);
+            EOS_ASSERT(fioaction_item != nullptr, contract_query_exception, "Action can't be found ${contract}",
+                       ("contract", params.action.to_string()));
+
+            string actionname = fioaction_item->contractname;
             name code = ::eosio::string_to_name(actionname.c_str());
 
             const auto code_account = db.db().find<account_object, by_name>(code);

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -100,6 +100,12 @@ namespace eosio {
             string status;          //the status of the request.
         };
 
+        struct action_record {
+            string action;
+            string contract;
+            string block_timestamp;
+        };
+
         struct whitelist_info {
             string fio_public_key_hash;
             string content;
@@ -476,6 +482,20 @@ namespace eosio {
             get_pending_fio_requests(const get_pending_fio_requests_params &params) const;
 
             //end get pending fio requests
+
+            //begin get actions fio requests
+            struct get_actions_params {
+                int32_t offset = 0;
+                int32_t limit = 0;
+            };
+
+            struct get_actions_result {
+                vector <action_record> actions;
+                uint32_t more;
+            };
+
+            get_actions_result get_actions(const get_actions_params &params) const;
+            //end get actions
 
             //begin get cancelled fio requests
             struct get_cancelled_fio_requests_params {
@@ -1375,6 +1395,8 @@ FC_REFLECT(eosio::chain_apis::read_only::get_cancelled_fio_requests_params, (fio
 FC_REFLECT(eosio::chain_apis::read_only::get_cancelled_fio_requests_result, (requests)(more))
 FC_REFLECT(eosio::chain_apis::read_only::get_sent_fio_requests_params, (fio_public_key)(offset)(limit))
 FC_REFLECT(eosio::chain_apis::read_only::get_sent_fio_requests_result, (requests)(more))
+FC_REFLECT(eosio::chain_apis::read_only::get_actions_params, (offset)(limit))
+FC_REFLECT(eosio::chain_apis::read_only::get_actions_result, (actions)(more))
 FC_REFLECT(eosio::chain_apis::read_only::get_obt_data_params, (fio_public_key)(offset)(limit))
 FC_REFLECT(eosio::chain_apis::read_only::get_obt_data_result, (obt_data_records)(more))
 FC_REFLECT(eosio::chain_apis::read_only::get_whitelist_params, (fio_public_key))
@@ -1389,6 +1411,7 @@ FC_REFLECT(eosio::chain_apis::request_status_record,
            (fio_request_id)(payer_fio_address)(payee_fio_address)(payer_fio_public_key)(payee_fio_public_key)(content)(
                    time_stamp)
                    (status))
+FC_REFLECT(eosio::chain_apis::action_record,(action)(contract)(block_timestamp))
 
 FC_REFLECT(eosio::chain_apis::obt_records,
            (payer_fio_address)(payee_fio_address)(payer_fio_public_key)(payee_fio_public_key)(content)(fio_request_id)(

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -8,6 +8,7 @@
 #include <eosio/chain/asset.hpp>
 #include <eosio/chain/authority.hpp>
 #include <eosio/chain/account_object.hpp>
+#include <eosio/chain/fioaction_object.hpp>
 #include <eosio/chain/block.hpp>
 #include <eosio/chain/controller.hpp>
 #include <eosio/chain/contract_table_objects.hpp>


### PR DESCRIPTION
this PR is for information purposes only.

This PR makes a new table in state called fioaction, this table holds the list of action names that are permitted to execute in the fio protocol..

the FIO controller chain initialization has been kludged to init the set of allowed actions.
the apply context is modified to read the new table and throw an error if the action name is not present in the table.

A new action is added to the system contract called updateacts, this inserts a new action into the fioaction table. 

this example is to only be used as a proof of concept....final protocol designs will be finalized the week of July 9.

