### PR TITLE
invalid_signature return string rename.

### DIFF
--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -767,7 +767,7 @@ namespace eosio {
 
         FC_DECLARE_DERIVED_EXCEPTION(fio_invalid_sig_exception, fio_exception,
                                      5010002,
-                                     "{ \n  \"type\": \"invalid_signature\",\n  \"message\": \"Request signature not valid or not allowed.\"\n}")
+                                     "{ \n  \"type\": \"invalid_signature\",\n  \"message\": \"Request signature is not valid or this user is not allowed to sign this transaction.\"\n}")
 
         FC_DECLARE_DERIVED_EXCEPTION(fio_invalid_trans_exception, fio_exception,
                                      5010003,

--- a/libraries/chain/include/eosio/chain/fioio/fioerror.hpp
+++ b/libraries/chain/include/eosio/chain/fioio/fioerror.hpp
@@ -155,7 +155,7 @@ namespace fioio {
 
     struct Code_403_Result : public Http_Result {
         Code_403_Result(uint64_t code) :
-                Http_Result("invalid_signature", "Request signature not valid or not allowed.") {
+                Http_Result("invalid_signature", "Request signature is not valid or this user is not allowed to sign this transaction.") {
             if (code == fioio::ErrorTransaction) {
                 type = "invalid_transaction";
                 message = "Signed transaction is not valid or is not formatted properly";

--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -660,7 +660,7 @@ namespace eosio {
         if (rescode == chain::unsatisfied_authorization().code() ||
             rescode == chain::fio_invalid_sig_exception().code()) {
             rescode = 403;
-            message = "{ \n  \"type\": \"invalid_signature\",\n  \"message\": \"Request signature not valid or not allowed.\"\n}";
+            message = "{ \n  \"type\": \"invalid_signature\",\n  \"message\": \"Request signature is not valid or this user is not allowed to sign this transaction.\"\n}";
         } else if (rescode == chain::fio_invalid_trans_exception().code()) {
             rescode = 403;
             message = "{ \n  \"type\": \"invalid_transaction\",\n  \"message\": \"Signed transaction is not valid or is not formatted properly.\"\n}";


### PR DESCRIPTION
The 'Request signature not valid or not allowed.' gets returned when a user does not have permission attempts to execute a transaction owned by another user.

The string was renamed 'Request signature is not valid or this user is not allowed to sign this transaction.' to allow for a more general response. 