### PR TITLE
[FIP-11.a] Add API endpoint for addbundles action

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -191,7 +191,9 @@ namespace eosio {
                                      CHAIN_RW_CALL_ASYNC(pay_tpid_rewards,
                                                          chain_apis::read_write::pay_tpid_rewards_results, 202),
                                      CHAIN_RW_CALL_ASYNC(claim_bp_rewards,
-                                                         chain_apis::read_write::claim_bp_rewards_results, 202)
+                                                         chain_apis::read_write::claim_bp_rewards_results, 202),
+                                     CHAIN_RW_CALL_ASYNC(add_bundled_transactions,
+                                                         chain_apis::read_write::add_bundled_transactions_results, 202)
 
                              });
     }

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -5443,6 +5443,58 @@ if( options.count(name) ) { \
             } CATCH_AND_CALL(next);
         }
 
+        void read_write::add_bundled_transactions(const read_write::add_bundled_transactions_params &params,
+                                          next_function<read_write::add_bundled_transactions_results> next) {
+
+            try {
+                FIO_403_ASSERT(params.size() == 4,
+                               fioio::ErrorTransaction); // variant object contains authorization, account, name, data
+                auto pretty_input = std::make_shared<packed_transaction>();
+                auto resolver = make_resolver(this, abi_serializer_max_time);
+                transaction_metadata_ptr ptrx;
+                dlog("add_bundled_transactions called");
+
+                try {
+                    abi_serializer::from_variant(params, *pretty_input, resolver, abi_serializer_max_time);
+                    ptrx = std::make_shared<transaction_metadata>(pretty_input);
+                } EOS_RETHROW_EXCEPTIONS(chain::fio_invalid_trans_exception, "Invalid transaction")
+
+                transaction trx = pretty_input->get_transaction();
+                vector<action> &actions = trx.actions;
+                dlog("\n");
+                dlog(actions[0].name.to_string());
+                FIO_403_ASSERT(trx.total_actions() == 1, fioio::InvalidAccountOrAction);
+
+                FIO_403_ASSERT(actions[0].authorization.size() > 0, fioio::ErrorTransaction);
+                FIO_403_ASSERT(actions[0].account.to_string() == "fio.address", fioio::InvalidAccountOrAction);
+                FIO_403_ASSERT(actions[0].name.to_string() == "addbundles", fioio::InvalidAccountOrAction);
+
+                app().get_method<incoming::methods::transaction_async>()(ptrx, true, [this, next](
+                        const fc::static_variant<fc::exception_ptr, transaction_trace_ptr> &result) -> void {
+                    if (result.contains<fc::exception_ptr>()) {
+                        next(result.get<fc::exception_ptr>());
+                    } else {
+                        auto trx_trace_ptr = result.get<transaction_trace_ptr>();
+
+                        try {
+                            fc::variant output;
+                            try {
+                                output = db.to_variant_with_abi(*trx_trace_ptr, abi_serializer_max_time);
+                            } catch (chain::abi_exception &) {
+                                output = *trx_trace_ptr;
+                            }
+
+                            const chain::transaction_id_type &id = trx_trace_ptr->id;
+                            next(read_write::add_bundled_transactions_results{id, output});
+                        } CATCH_AND_CALL(next);
+                    }
+                });
+
+
+            } catch (boost::interprocess::bad_alloc &) {
+                chain_plugin::handle_db_exhaustion();
+            } CATCH_AND_CALL(next);
+        }
 
         void read_write::push_transaction(const read_write::push_transaction_params &params,
                                           next_function<read_write::push_transaction_results> next) {

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -1281,6 +1281,18 @@ namespace eosio {
                                   chain::plugin_interface::next_function<claim_bp_rewards_results> next);
 
             //End added for new claim_bp_rewards api method.
+
+            //Begin Added for add_bundled_transactions api method
+            using add_bundled_transactions_params = fc::variant_object;
+
+            struct add_bundled_transactions_results {
+                chain::transaction_id_type transaction_id;
+                fc::variant processed;
+            };
+
+            void add_bundled_transactions(const add_bundled_transactions_params &params,
+                                  chain::plugin_interface::next_function<add_bundled_transactions_results> next);
+            //end
             using push_transactions_params  = vector<push_transaction_params>;
             using push_transactions_results = vector<push_transaction_results>;
 
@@ -1535,6 +1547,7 @@ FC_REFLECT(eosio::chain_apis::read_write::renew_fio_address_results, (transactio
 FC_REFLECT(eosio::chain_apis::read_write::new_funds_request_results, (transaction_id)(processed));
 FC_REFLECT(eosio::chain_apis::read_write::pay_tpid_rewards_results, (transaction_id)(processed));
 FC_REFLECT(eosio::chain_apis::read_write::claim_bp_rewards_results, (transaction_id)(processed));
+FC_REFLECT(eosio::chain_apis::read_write::add_bundled_transactions_results, (transaction_id)(processed));
 
 FC_REFLECT(eosio::chain_apis::read_only::get_table_by_scope_params,
            (code)(table)(lower_bound)(upper_bound)(limit)(reverse))


### PR DESCRIPTION
This PR adds signed transaction reference for`add_bundled_transactions` to the chain plugin.