### PR TITLE
add handling for voters2 table to get_account

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -5824,10 +5824,20 @@ if( options.count(name) ) { \
                 get_table_rows_result voter_result = get_table_rows_by_seckey<index64_index, uint64_t>(
                         voter_table, system_abi, [](uint64_t v) -> uint64_t {
                             return v;
+                 });
+                  if (!voter_result.rows.empty()) {
+                    result.voter_info = voter_result.rows[0];
+                  }
+                  else {
+                        voter_table.table = "voters2";
+                        get_table_rows_result voter2_result = get_table_rows_by_seckey<index64_index, uint64_t>(
+                                voter_table, system_abi, [](uint64_t v) -> uint64_t {
+                                    return v;
                         });
-                        if (!voter_result.rows.empty()) {
-                          result.voter_info = voter_result.rows[0];
-                        }
+                            if (!voter2_result.rows.empty()) {
+                              result.voter_info = voter2_result.rows[0];
+                            }
+                  }
             }
             return result;
         }


### PR DESCRIPTION
Update to v1/chain/get_account

Voters table will be migrated to voters2 in future contract release. This update ensures calls to get_account in chain_plugin searches either the voters or voters2 table for reliable data until all nodes have had a chance to update. 