### PR TITLE
Update build scripts to use clang-8/llvm-8

### DIFF
--- a/scripts/helpers/.build_vars
+++ b/scripts/helpers/.build_vars
@@ -37,7 +37,7 @@ export BOOST_ROOT=${BOOST_LOCATION:-${SRC_DIR}/boost_${BOOST_VERSION}}
 export BOOST_LINK_LOCATION=${OPT_DIR}/boost
 
 # LLVM
-export LLVM_VERSION=release_40
+export LLVM_VERSION=release_80
 export LLVM_ROOT=${OPT_DIR}/llvm
 export LLVM_DIR=${LLVM_ROOT}/lib/cmake/llvm
 

--- a/scripts/helpers/build_ubuntu.sh
+++ b/scripts/helpers/build_ubuntu.sh
@@ -12,6 +12,7 @@ echo "Disk space available: ${DISK_AVAIL}G"
 
 # system clang and build essential for Ubuntu 18 (16 too old)
 ( [[ $PIN_COMPILER == false ]] && [[ $VERSION_ID == "18.04" ]] ) && EXTRA_DEPS=(clang-8,dpkg\ -s)
+( [[ $PIN_COMPILER == false ]] && [[ $VERSION_ID == "18.04" ]] ) && EXTRA_DEPS=(llvm-8,dpkg\ -s)
 # We install clang8 for Ubuntu 16, but we still need something to compile cmake, boost, etc + pinned 18 still needs something to build source
 ( [[ $VERSION_ID == "16.04" ]] || ( $PIN_COMPILER && [[ $VERSION_ID == "18.04" ]] ) ) && ensure-build-essential
 # Ensure packages exist

--- a/scripts/helpers/build_ubuntu.sh
+++ b/scripts/helpers/build_ubuntu.sh
@@ -12,11 +12,10 @@ echo "Disk space available: ${DISK_AVAIL}G"
 
 # system clang and build essential for Ubuntu 18 (16 too old)
 ( [[ $PIN_COMPILER == false ]] && [[ $VERSION_ID == "18.04" ]] ) && EXTRA_DEPS=(clang-8,dpkg\ -s)
-( [[ $PIN_COMPILER == false ]] && [[ $VERSION_ID == "18.04" ]] ) && EXTRA_DEPS=(llvm-8,dpkg\ -s)
 # We install clang8 for Ubuntu 16, but we still need something to compile cmake, boost, etc + pinned 18 still needs something to build source
 ( [[ $VERSION_ID == "16.04" ]] || ( $PIN_COMPILER && [[ $VERSION_ID == "18.04" ]] ) ) && ensure-build-essential
 # Ensure packages exist
-([[ $PIN_COMPILER == false ]] && [[ $BUILD_CLANG == false ]]) && EXTRA_DEPS+=(llvm-4.0,dpkg\ -s)
+([[ $PIN_COMPILER == false ]] && [[ $BUILD_CLANG == false ]]) && EXTRA_DEPS+=(llvm-8,dpkg\ -s)
 $ENABLE_COVERAGE_TESTING && EXTRA_DEPS+=(lcov,dpkg\ -s)
 ensure-apt-packages "${REPO_ROOT}/scripts/helpers/build_ubuntu_deps" $(echo ${EXTRA_DEPS[@]})
 echo ""

--- a/scripts/helpers/build_ubuntu.sh
+++ b/scripts/helpers/build_ubuntu.sh
@@ -11,7 +11,7 @@ echo "Disk space available: ${DISK_AVAIL}G"
 [[ "${DISK_AVAIL}" -lt "${DISK_MIN}" ]] && echo " - You must have at least ${DISK_MIN}GB of available storage to install EOSIO." && exit 1
 
 # system clang and build essential for Ubuntu 18 (16 too old)
-( [[ $PIN_COMPILER == false ]] && [[ $VERSION_ID == "18.04" ]] ) && EXTRA_DEPS=(clang,dpkg\ -s)
+( [[ $PIN_COMPILER == false ]] && [[ $VERSION_ID == "18.04" ]] ) && EXTRA_DEPS=(clang-8,dpkg\ -s)
 # We install clang8 for Ubuntu 16, but we still need something to compile cmake, boost, etc + pinned 18 still needs something to build source
 ( [[ $VERSION_ID == "16.04" ]] || ( $PIN_COMPILER && [[ $VERSION_ID == "18.04" ]] ) ) && ensure-build-essential
 # Ensure packages exist

--- a/scripts/helpers/fio_helper.sh
+++ b/scripts/helpers/fio_helper.sh
@@ -175,10 +175,12 @@ function ensure-compiler() {
                 ### Check for apple clang version 10 or higher
                 [[ $( $(which $CXX) --version | cut -d ' ' -f 4 | cut -d '.' -f 1 | head -n 1 ) -lt 10 ]] && export NO_CPP17=true
             else
-                if [[ $( $(which $CXX) --version | cut -d ' ' -f 3 | head -n 1 | cut -d '.' -f1) =~ ^[0-9]+$ ]]; then # Check if the version message cut returns an integer
-                    [[ $( $(which $CXX) --version | cut -d ' ' -f 3 | head -n 1 | cut -d '.' -f1) < 6 ]] && export NO_CPP17=true
-                elif [[ $(clang --version | cut -d ' ' -f 4 | head -n 1 | cut -d '.' -f1) =~ ^[0-9]+$ ]]; then # Check if the version message cut returns an integer
-                    [[ $( $(which $CXX) --version | cut -d ' ' -f 4 | cut -d '.' -f 1 | head -n 1 ) < 6 ]] && export NO_CPP17=true
+                if [[ $( $(which $CXX) --version | cut -d ' ' -f 3 | head -n 1 | cut -d '.' -f1) =~ ^[0-9]+$ ]] && \
+                    [[ $( $(which $CXX) --version | cut -d ' ' -f 3 | head -n 1 | cut -d '.' -f1) < 8 ]]; then
+                      [[ -f "$(which $CXX)-8" ]] && { export CXX="$(which $CXX)-8"; echo "${COLOR_YELLOW}WARNING: clang was less than version 8, using ${CXX} instead${COLOR_NC}"; sleep 2; } || export NO_CPP17=true
+                elif [[ $(clang --version | cut -d ' ' -f 4 | head -n 1 | cut -d '.' -f1) =~ ^[0-9]+$ ]] && \
+                    [[ $( $(which $CXX) --version | cut -d ' ' -f 4 | cut -d '.' -f 1 | head -n 1 ) < 8 ]]; then
+                      [[ -f "$(which $CXX)-8" ]] && { export CXX="$(which $CXX)-8"; echo "${COLOR_YELLOW}WARNING: clang was less than version 8, using ${CXX} instead${COLOR_NC}";  sleep 2; } || export NO_CPP17=true
                 fi
             fi
         else

--- a/scripts/helpers/fio_helper.sh
+++ b/scripts/helpers/fio_helper.sh
@@ -157,8 +157,8 @@ function ensure-compiler() {
         export CXX=${CXX:-'g++'}
         export CC=${CC:-'gcc'}
     fi
-    export CXX=${CXX:-'clang++'}
-    export CC=${CC:-'clang'}
+    export CXX=${CXX:-'clang++-8'}
+    export CC=${CC:-'clang-8'}
     if $PIN_COMPILER || [[ -f $CLANG_ROOT/bin/clang++ ]]; then
         export PIN_COMPILER=true
         export BUILD_CLANG=true
@@ -177,10 +177,10 @@ function ensure-compiler() {
             else
                 if [[ $( $(which $CXX) --version | cut -d ' ' -f 3 | head -n 1 | cut -d '.' -f1) =~ ^[0-9]+$ ]] && \
                     [[ $( $(which $CXX) --version | cut -d ' ' -f 3 | head -n 1 | cut -d '.' -f1) < 8 ]]; then
-                      [[ -f "$(which $CXX)-8" ]] && { export CXX="$(which $CXX)-8"; echo "${COLOR_YELLOW}WARNING: clang was less than version 8, using ${CXX} instead${COLOR_NC}"; sleep 2; } || export NO_CPP17=true
+                      [[ -f "$(which $CXX)-8" ]] && { export CPP="$(which $CPP)-8"; export CXX="$(which $CXX)-8"; echo "${COLOR_YELLOW}WARNING: clang was less than version 8, using ${CXX} instead${COLOR_NC}";  sleep 2; } || export NO_CPP17=true
                 elif [[ $(clang --version | cut -d ' ' -f 4 | head -n 1 | cut -d '.' -f1) =~ ^[0-9]+$ ]] && \
                     [[ $( $(which $CXX) --version | cut -d ' ' -f 4 | cut -d '.' -f 1 | head -n 1 ) < 8 ]]; then
-                      [[ -f "$(which $CXX)-8" ]] && { export CXX="$(which $CXX)-8"; echo "${COLOR_YELLOW}WARNING: clang was less than version 8, using ${CXX} instead${COLOR_NC}";  sleep 2; } || export NO_CPP17=true
+                      [[ -f "$(which $CXX)-8" ]] && { export CPP="$(which $CPP)-8"; export CXX="$(which $CXX)-8"; echo "${COLOR_YELLOW}WARNING: clang was less than version 8, using ${CXX} instead${COLOR_NC}";  sleep 2; } || export NO_CPP17=true
                 fi
             fi
         else
@@ -279,8 +279,8 @@ function ensure-llvm() {
             CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX='${LLVM_ROOT}' -DLLVM_TARGETS_TO_BUILD=host -DLLVM_BUILD_TOOLS=false -DLLVM_ENABLE_RTTI=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE='${BUILD_DIR}/pinned_toolchain.cmake' .."
         else
             if [[ $NAME == "Ubuntu" ]]; then
-                execute ln -s /usr/lib/llvm-4.0 $LLVM_ROOT
-                echo " - LLVM successfully linked from /usr/lib/llvm-4.0 to ${LLVM_ROOT}"
+                execute ln -s /usr/lib/llvm-8 $LLVM_ROOT
+                echo " - LLVM successfully linked from /usr/lib/llvm-8 to ${LLVM_ROOT}"
                 return 0
             fi
             CMAKE_FLAGS="-G 'Unix Makefiles' -DCMAKE_INSTALL_PREFIX=${LLVM_ROOT} -DLLVM_TARGETS_TO_BUILD='host' -DLLVM_BUILD_TOOLS=false -DLLVM_ENABLE_RTTI=1 -DCMAKE_BUILD_TYPE=Release .."


### PR DESCRIPTION
Using clang-6 and llvm-6 on Ubuntu 18.04 can cause problems with saving state under certain circumstances.

This PR updates the scripts to use version 8 of both. The update will require using a snapshot to recover state, but will not invalidate the blocks.log.