### PR TITLE
[FIP-25] add bundle count to get fio names results

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2326,6 +2326,7 @@ if( options.count(name) ) { \
 
             std::string nam;
             uint64_t namexpiration;
+            uint64_t rem_bundle;
             time_t temptime;
             struct tm *timeinfo;
             char buffer[80];
@@ -2339,12 +2340,14 @@ if( options.count(name) ) { \
                     if (nam.find('@') !=
                         std::string::npos) { //if it's not a domain record in the keynames table (no '.'),
                         namexpiration = table_rows_result.rows[pos]["expiration"].as_uint64();
+                        rem_bundle = (uint64_t) table_rows_result.rows[pos]["bundleeligiblecountdown"].as_uint64();
+
 
                         temptime = namexpiration;
                         timeinfo = gmtime(&temptime);
                         strftime(buffer, 80, "%Y-%m-%dT%T", timeinfo);
 
-                        fioaddress_record fa{nam, buffer};
+                        fioaddress_record fa{nam, buffer,rem_bundle};
                         result.fio_addresses.push_back(fa);
                     }
                 } // Get FIO domains and push

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -65,6 +65,7 @@ namespace eosio {
         struct fioaddress_record {
             string fio_address;
             string expiration;
+            uint64_t remaining_bundled_tx = 0;
         };
 
         struct request_record {
@@ -1522,7 +1523,7 @@ FC_REFLECT(eosio::chain_apis::read_only::address_info, (public_address)(token_co
 FC_REFLECT(eosio::chain_apis::read_only::get_pub_addresses_params, (fio_address)(offset)(limit))
 FC_REFLECT(eosio::chain_apis::read_only::get_pub_addresses_result, (public_addresses)(more));
 FC_REFLECT(eosio::chain_apis::fiodomain_record, (fio_domain)(expiration)(is_public))
-FC_REFLECT(eosio::chain_apis::fioaddress_record, (fio_address)(expiration))
+FC_REFLECT(eosio::chain_apis::fioaddress_record, (fio_address)(expiration)(remaining_bundled_tx))
 FC_REFLECT(eosio::chain_apis::read_only::get_fio_names_params, (fio_public_key))
 FC_REFLECT(eosio::chain_apis::read_only::get_fio_names_result, (fio_domains)(fio_addresses));
 FC_REFLECT(eosio::chain_apis::read_only::get_fio_domains_params, (fio_public_key)(offset)(limit))


### PR DESCRIPTION
these changes add the bundle count to the address data returned for get_fio_names

these changes implement FIP-25.   https://github.com/fioprotocol/fips/blob/master/fip-0025.md

a new attribute is added to the results for addresses to note the bundle count for the address

this was tested by running the javascript test on the local dev build.
