### PR TITLE
BD-2427  integrate new nodeos switch --init-addaction

### DIFF
--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -98,6 +98,7 @@ namespace eosio {
                 bool contracts_console = false;
                 bool allow_ram_billing_in_notify = false;
                 bool disable_all_subjective_mitigations = false; //< for testing purposes only
+                bool init_add_action = false;
 
                 genesis_state genesis;
                 wasm_interface::vm_type wasm_runtime = chain::config::default_wasm_runtime;
@@ -128,7 +129,7 @@ namespace eosio {
 
             void add_indices();
 
-            void startup(std::function<bool()> shutdown, const snapshot_reader_ptr &snapshot = nullptr);
+            void startup(std::function<bool()> shutdown, const bool &initaddaction = false, const snapshot_reader_ptr &snapshot = nullptr);
 
             void preactivate_feature(const digest_type &feature_digest);
 

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -213,7 +213,7 @@ namespace eosio {
         void base_tester::open(protocol_feature_set &&pfs, const snapshot_reader_ptr &snapshot) {
             control.reset(new controller(cfg, std::move(pfs)));
             control->add_indices();
-            control->startup([]() { return false; }, snapshot);
+            control->startup([]() { return false; }, false, snapshot);
             chain_transactions.clear();
             control->accepted_block.connect([this](const block_state_ptr &block_state) {
                 FC_ASSERT(block_state->block);


### PR DESCRIPTION
integrate new nodeos switch init-addaction to init the actions table for local dev.
this switch should be used whenever using the fio.devtools for startup (local testing, dev net testing).

NOTE-- the verification of dev net needs to be completed before these changes are merged.
this PR depends on BD-2427 PRs in the fio.devtools and dapixio/fio-devnet repos.

