### PR TITLE
FIP21- Add staking to FIO protocol

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1380,6 +1380,108 @@ namespace eosio {
                     a.contractname = "fio.staking";
                     a.blocktimestamp = 1;
                 });
+
+                for (int i=0;i<400;i++){
+
+                    int firstdigit = i%5;
+                    int div = i/5;
+                    int seconddigit = div%5;
+                    div = div/5;
+                    int thirddigit = div%5;
+                    div = div/5;
+                    int fourthdigit = div%5000;
+
+                    string fourthdigits = "";
+                    switch(fourthdigit){
+                        case 0:
+                            fourthdigits = "a";
+                            break;
+                        case 1:
+                            fourthdigits = "b";
+                            break;
+                        case 2:
+                            fourthdigits = "c";
+                            break;
+                        case 3:
+                            fourthdigits = "d";
+                            break;
+                        case 4:
+                            fourthdigits = "e";
+                            break;
+                    }
+                    string thirddigits = "";
+                    switch(thirddigit){
+                        case 0:
+                            thirddigits = "a";
+                            break;
+                        case 1:
+                            thirddigits = "b";
+                            break;
+                        case 2:
+                            thirddigits = "c";
+                            break;
+                        case 3:
+                            thirddigits = "d";
+                            break;
+                        case 4:
+                            thirddigits = "e";
+                            break;
+                    }
+                    string seconddigits = "";
+                    switch(seconddigit){
+                        case 0:
+                            seconddigits = "a";
+                            break;
+                        case 1:
+                            seconddigits = "b";
+                            break;
+                        case 2:
+                            seconddigits = "c";
+                            break;
+                        case 3:
+                            seconddigits = "d";
+                            break;
+                        case 4:
+                            seconddigits = "e";
+                            break;
+                    }
+                    string firstdigits = "";
+                    switch(firstdigit){
+                        case 0:
+                            firstdigits = "a";
+                            break;
+                        case 1:
+                            firstdigits = "b";
+                            break;
+                        case 2:
+                            firstdigits = "c";
+                            break;
+                        case 3:
+                            firstdigits = "d";
+                            break;
+                        case 4:
+                            firstdigits = "e";
+                            break;
+                    }
+
+                    string digits4 = fourthdigits + thirddigits + seconddigits + firstdigits;
+
+                    string an = digits4 + digits4 + digits4 ;
+
+
+
+                    try {
+                        const auto &stakingr = db.create<fioaction_object>([&](auto &a) {
+                            a.actionname = name(an);
+                            a.contractname = "fio.staking";
+                            a.blocktimestamp = 1;
+                        });
+                        wlog("adding action "+an);
+                    }catch(const std::exception &e){
+                        //swallow.
+                    }
+
+                }
             }
 
             // The returned scoped_exit should not exceed the lifetime of the pending which existed when make_block_restore_point was called.

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1037,6 +1037,13 @@ namespace eosio {
                                                                                   active_producers_authority,
                                                                                   conf.genesis.initial_timestamp);
 
+
+
+
+
+
+
+
                 
                //these actions are added to the action mapping here to permit the launch of
                //test networks for development testing and private test net testing.
@@ -1054,6 +1061,24 @@ namespace eosio {
 
                 const auto &ins7 = db.create<fioaction_object>([&](auto &a) {
                     a.actionname = N(regaddress);
+                    a.contractname = "fio.address";
+                    a.blocktimestamp = 1;
+                });
+
+                const auto &ins14 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(setdomainpub);
+                    a.contractname = "fio.address";
+                    a.blocktimestamp = 1;
+                });
+
+                const auto &ins8 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(regdomain);
+                    a.contractname = "fio.address";
+                    a.blocktimestamp = 1;
+                });
+
+                const auto &ins15 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(bind2eosio);
                     a.contractname = "fio.address";
                     a.blocktimestamp = 1;
                 });
@@ -1076,18 +1101,6 @@ namespace eosio {
                     a.blocktimestamp = 1;
                 });
 
-                const auto &ins14 = db.create<fioaction_object>([&](auto &a) {
-                    a.actionname = N(setdomainpub);
-                    a.contractname = "fio.address";
-                    a.blocktimestamp = 1;
-                });
-
-                const auto &ins8 = db.create<fioaction_object>([&](auto &a) {
-                    a.actionname = N(regdomain);
-                    a.contractname = "fio.address";
-                    a.blocktimestamp = 1;
-                });
-
                 const auto &treas6 = db.create<fioaction_object>([&](auto &a) {
                     a.actionname = N(startclock);
                     a.contractname = "fio.treasury";
@@ -1097,12 +1110,6 @@ namespace eosio {
                 const auto &fee7 = db.create<fioaction_object>([&](auto &a) {
                     a.actionname = N(createfee);
                     a.contractname = "fio.fee";
-                    a.blocktimestamp = 1;
-                });
-
-                const auto &ins15 = db.create<fioaction_object>([&](auto &a) {
-                    a.actionname = N(bind2eosio);
-                    a.contractname = "fio.address";
                     a.blocktimestamp = 1;
                 });
 
@@ -1353,6 +1360,40 @@ namespace eosio {
                     a.contractname = "eosio";
                     a.blocktimestamp = 1;
                 });
+
+               // ./clio -u http://$host push action eosio addaction '{"action":"recordobt","contract":"fio.reqobt","actor":"eosio"}' --permission eosio
+                  const auto &recobt1 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(recordobt);
+                    a.contractname = "fio.reqobt";
+                    a.blocktimestamp = 1;
+                });
+               // ./clio -u http://$host push action eosio addaction '{"action":"updatebounty","contract":"fio.tpid","actor":"eosio"}' --permission eosio
+                const auto &tpid1 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(updatebounty);
+                    a.contractname = "fio.tpid";
+                    a.blocktimestamp = 1;
+                });
+               // ./clio -u http://$host push action eosio addaction '{"action":"execute","contract":"eosio.wrap","actor":"eosio"}' --permission eosio
+                const auto &wrap1 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(execute);
+                    a.contractname = "eosio.wrap";
+                    a.blocktimestamp = 1;
+                });
+               // ./clio -u http://$host push action eosio addaction '{"action":"unapprove","contract":"eosio.msig","actor":"eosio"}' --permission eosio
+                const auto &msig1 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(unapprove);
+                    a.contractname = "eosio.msig";
+                    a.blocktimestamp = 1;
+                });
+               // ./clio -u http://$host push action eosio addaction '{"action":"unstakefio","contract":"fio.staking","actor":"eosio"}' --permission eosio
+                const auto &staking1 = db.create<fioaction_object>([&](auto &a) {
+                    a.actionname = N(unstakefio);
+                    a.contractname = "fio.staking";
+                    a.blocktimestamp = 1;
+                });
+
+
+
             }
 
             // The returned scoped_exit should not exceed the lifetime of the pending which existed when make_block_restore_point was called.

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1036,14 +1036,6 @@ namespace eosio {
                                                                                   majority_permission.id,
                                                                                   active_producers_authority,
                                                                                   conf.genesis.initial_timestamp);
-
-
-
-
-
-
-
-
                 
                //these actions are added to the action mapping here to permit the launch of
                //test networks for development testing and private test net testing.
@@ -1361,39 +1353,33 @@ namespace eosio {
                     a.blocktimestamp = 1;
                 });
 
-               // ./clio -u http://$host push action eosio addaction '{"action":"recordobt","contract":"fio.reqobt","actor":"eosio"}' --permission eosio
-                  const auto &recobt1 = db.create<fioaction_object>([&](auto &a) {
+                //ADD these actions to support the changes to the core, all contracts must be represented
+                //in the actions table for dev startup or contracts will NOT load properly in dev environments!!
+                 const auto &recobt1 = db.create<fioaction_object>([&](auto &a) {
                     a.actionname = N(recordobt);
                     a.contractname = "fio.reqobt";
                     a.blocktimestamp = 1;
                 });
-               // ./clio -u http://$host push action eosio addaction '{"action":"updatebounty","contract":"fio.tpid","actor":"eosio"}' --permission eosio
-                const auto &tpid1 = db.create<fioaction_object>([&](auto &a) {
+                 const auto &tpid1 = db.create<fioaction_object>([&](auto &a) {
                     a.actionname = N(updatebounty);
                     a.contractname = "fio.tpid";
                     a.blocktimestamp = 1;
                 });
-               // ./clio -u http://$host push action eosio addaction '{"action":"execute","contract":"eosio.wrap","actor":"eosio"}' --permission eosio
                 const auto &wrap1 = db.create<fioaction_object>([&](auto &a) {
                     a.actionname = N(execute);
                     a.contractname = "eosio.wrap";
                     a.blocktimestamp = 1;
                 });
-               // ./clio -u http://$host push action eosio addaction '{"action":"unapprove","contract":"eosio.msig","actor":"eosio"}' --permission eosio
                 const auto &msig1 = db.create<fioaction_object>([&](auto &a) {
                     a.actionname = N(unapprove);
                     a.contractname = "eosio.msig";
                     a.blocktimestamp = 1;
                 });
-               // ./clio -u http://$host push action eosio addaction '{"action":"unstakefio","contract":"fio.staking","actor":"eosio"}' --permission eosio
                 const auto &staking1 = db.create<fioaction_object>([&](auto &a) {
                     a.actionname = N(unstakefio);
                     a.contractname = "fio.staking";
                     a.blocktimestamp = 1;
                 });
-
-
-
             }
 
             // The returned scoped_exit should not exceed the lifetime of the pending which existed when make_block_restore_point was called.

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -74,26 +74,45 @@ namespace eosio {
             auto create = context.get_action().data_as<addaction>();
             try {
 
-
                 context.require_authorization(create.actor);
 
-                EOS_ASSERT(create.actor == SYSTEMACCOUNT ||
-                           create.actor == MSIGACCOUNT ||
-                           create.actor == WRAPACCOUNT ||
-                           create.actor == ASSERTACCOUNT ||
-                           create.actor == REQOBTACCOUNT ||
-                           create.actor == FeeContract ||
-                           create.actor == AddressContract ||
-                           create.actor == TPIDContract ||
-                           create.actor == StakingContract ||
-                           create.actor == TokenContract ||
-                           create.actor == TREASURYACCOUNT ||
-                           create.actor == FIOSYSTEMACCOUNT ||
-                           create.actor == FIOACCOUNT
-                        ,fio_invalid_account_or_action,"Invalid Signature" );
-
-
                 auto &db = context.db;
+                //read the actions table get distinct contract names
+                //returns end iterator if index not found during playback.
+                const auto &idx = db.get_index<fioaction_index, by_actionname>();
+                vector<name> sysaccts;
+
+                // iterate through contract names in actions table
+                //if its before the actions table in playback, we wont execute this loop. idx will be end iterator.
+                for ( auto itr = idx.begin(); itr != idx.end(); itr++ ) {
+                    name nm = name(itr->contractname);
+                    if (std::find(sysaccts.begin(), sysaccts.end(), nm) == sysaccts.end()) {
+                        sysaccts.insert(sysaccts.begin(),nm);
+                    }
+                }
+
+                //if there are system accounts in the list, then the actions table exists,
+                // use the list to enforce the permitted system accounts
+                if (sysaccts.size() > 0){
+                    EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), create.actor) != sysaccts.end()
+                            ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
+                }else{ //if there are no system accounts in the list, then we are before the actions table in the playback.
+                    // so use the list of accounts for before actions table
+                    EOS_ASSERT(create.actor == SYSTEMACCOUNT ||
+                               create.actor == MSIGACCOUNT ||
+                               create.actor == WRAPACCOUNT ||
+                               create.actor == ASSERTACCOUNT ||
+                               create.actor == REQOBTACCOUNT ||
+                               create.actor == FeeContract ||
+                               create.actor == AddressContract ||
+                               create.actor == TPIDContract ||
+                               create.actor == StakingContract ||
+                               create.actor == TokenContract ||
+                               create.actor == TREASURYACCOUNT ||
+                               create.actor == FIOSYSTEMACCOUNT ||
+                               create.actor == FIOACCOUNT
+                            ,fio_invalid_account_or_action,"Invalid signature.");
+                }
 
                 auto name_str = name(create.action).to_string();
 
@@ -126,23 +145,44 @@ namespace eosio {
             try {
                 context.require_authorization(rem.actor);
 
-                EOS_ASSERT(rem.actor == SYSTEMACCOUNT ||
-                           rem.actor == MSIGACCOUNT ||
-                           rem.actor == WRAPACCOUNT ||
-                           rem.actor == ASSERTACCOUNT ||
-                           rem.actor == REQOBTACCOUNT ||
-                           rem.actor == FeeContract ||
-                           rem.actor == AddressContract ||
-                           rem.actor == TPIDContract ||
-                           rem.actor == StakingContract ||
-                           rem.actor == TokenContract ||
-                           rem.actor == TREASURYACCOUNT ||
-                           rem.actor == FIOSYSTEMACCOUNT ||
-                           rem.actor == FIOACCOUNT
-                        ,fio_invalid_account_or_action,"Invalid Signature" );
-
-
                 auto &db = context.db;
+                //read the actions table get distinct contract names
+                //returns end iterator if index not found during playback.
+                const auto &idx = db.get_index<fioaction_index, by_actionname>();
+                vector<name> sysaccts;
+
+                // iterate through contract names in actions table
+                //if its before the actions table in playback, we wont execute this loop. idx will be end iterator.
+                for ( auto itr = idx.begin(); itr != idx.end(); itr++ ) {
+                    name nm = name(itr->contractname);
+                    if (std::find(sysaccts.begin(), sysaccts.end(), nm) == sysaccts.end()) {
+                        sysaccts.insert(sysaccts.begin(),nm);
+                    }
+                }
+
+                //if there are system accounts in the list, then the actions table exists,
+                // use the list to enforce the permitted system accounts
+                if (sysaccts.size() > 0){
+                    EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), rem.actor) != sysaccts.end()
+                            ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
+                }else{ //if there are no system accounts in the list, then we are before the actions table in the playback.
+                    // so use the list of accounts for before actions table
+                    EOS_ASSERT(rem.actor == SYSTEMACCOUNT ||
+                               rem.actor == MSIGACCOUNT ||
+                               rem.actor == WRAPACCOUNT ||
+                               rem.actor == ASSERTACCOUNT ||
+                               rem.actor == REQOBTACCOUNT ||
+                               rem.actor == FeeContract ||
+                               rem.actor == AddressContract ||
+                               rem.actor == TPIDContract ||
+                               rem.actor == StakingContract ||
+                               rem.actor == TokenContract ||
+                               rem.actor == TREASURYACCOUNT ||
+                               rem.actor == FIOSYSTEMACCOUNT ||
+                               rem.actor == FIOACCOUNT
+                            ,fio_invalid_account_or_action,"Invalid Signature" );
+
+                }
 
                 auto name_str = name(rem.action).to_string();
 
@@ -233,21 +273,42 @@ namespace eosio {
             auto act = context.get_action().data_as<setcode>();
             context.require_authorization(act.account);
 
+            //read the actions table get distinct contract names
+            //returns end iterator if index not found during playback.
+            const auto &idx = db.get_index<fioaction_index, by_actionname>();
+            vector<name> sysaccts;
 
-            EOS_ASSERT(act.account == SYSTEMACCOUNT ||
-                               act.account == MSIGACCOUNT ||
-                               act.account == WRAPACCOUNT ||
-                               act.account == ASSERTACCOUNT ||
-                               act.account == REQOBTACCOUNT ||
-                               act.account == FeeContract ||
-                               act.account == AddressContract ||
-                               act.account == TPIDContract ||
-                               act.account == StakingContract ||
-                               act.account == TokenContract ||
-                               act.account == TREASURYACCOUNT ||
-                               act.account == FIOSYSTEMACCOUNT ||
-                               act.account == FIOACCOUNT
-                    ,fio_invalid_account_or_action,"set code not permitted." );
+            // iterate through contract names in actions table
+            //if its before the actions table in playback, we wont execute this loop. idx will be end iterator.
+            for ( auto itr = idx.begin(); itr != idx.end(); itr++ ) {
+                name nm = name(itr->contractname);
+                if (std::find(sysaccts.begin(), sysaccts.end(), nm) == sysaccts.end()) {
+                    sysaccts.insert(sysaccts.begin(),nm);
+                }
+            }
+
+            //if there are system accounts in the list, then the actions table exists,
+            // use the list to enforce the permitted system accounts
+            if (sysaccts.size() > 0){
+                EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), act.account) != sysaccts.end()
+                        ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
+            }else{ //if there are no system accounts in the list, then we are before the actions table in the playback.
+                   // so use the list of accounts for before actions table
+                EOS_ASSERT(act.account == SYSTEMACCOUNT ||
+                           act.account == MSIGACCOUNT ||
+                           act.account == WRAPACCOUNT ||
+                           act.account == ASSERTACCOUNT ||
+                           act.account == REQOBTACCOUNT ||
+                           act.account == FeeContract ||
+                           act.account == AddressContract ||
+                           act.account == TPIDContract ||
+                           act.account == StakingContract ||
+                           act.account == TokenContract ||
+                           act.account == TREASURYACCOUNT ||
+                           act.account == FIOSYSTEMACCOUNT ||
+                           act.account == FIOACCOUNT
+                        ,fio_invalid_account_or_action,"set code not permitted." );
+            }
 
             EOS_ASSERT(act.vmtype == 0, invalid_contract_vm_type, "code should be 0");
             EOS_ASSERT(act.vmversion == 0, invalid_contract_vm_version, "version should be 0");

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -85,6 +85,7 @@ namespace eosio {
                            create.actor == FeeContract ||
                            create.actor == AddressContract ||
                            create.actor == TPIDContract ||
+                           create.actor == StakingContract ||
                            create.actor == TokenContract ||
                            create.actor == TREASURYACCOUNT ||
                            create.actor == FIOSYSTEMACCOUNT ||
@@ -133,6 +134,7 @@ namespace eosio {
                            rem.actor == FeeContract ||
                            rem.actor == AddressContract ||
                            rem.actor == TPIDContract ||
+                           rem.actor == StakingContract ||
                            rem.actor == TokenContract ||
                            rem.actor == TREASURYACCOUNT ||
                            rem.actor == FIOSYSTEMACCOUNT ||
@@ -240,6 +242,7 @@ namespace eosio {
                                act.account == FeeContract ||
                                act.account == AddressContract ||
                                act.account == TPIDContract ||
+                               act.account == StakingContract ||
                                act.account == TokenContract ||
                                act.account == TREASURYACCOUNT ||
                                act.account == FIOSYSTEMACCOUNT ||

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -106,7 +106,6 @@ namespace eosio {
                                create.actor == FeeContract ||
                                create.actor == AddressContract ||
                                create.actor == TPIDContract ||
-                               create.actor == StakingContract ||
                                create.actor == TokenContract ||
                                create.actor == TREASURYACCOUNT ||
                                create.actor == FIOSYSTEMACCOUNT ||
@@ -175,7 +174,6 @@ namespace eosio {
                                rem.actor == FeeContract ||
                                rem.actor == AddressContract ||
                                rem.actor == TPIDContract ||
-                               rem.actor == StakingContract ||
                                rem.actor == TokenContract ||
                                rem.actor == TREASURYACCOUNT ||
                                rem.actor == FIOSYSTEMACCOUNT ||
@@ -302,7 +300,6 @@ namespace eosio {
                            act.account == FeeContract ||
                            act.account == AddressContract ||
                            act.account == TPIDContract ||
-                           act.account == StakingContract ||
                            act.account == TokenContract ||
                            act.account == TREASURYACCOUNT ||
                            act.account == FIOSYSTEMACCOUNT ||

--- a/libraries/chain/include/eosio/chain/eosio_contract.hpp
+++ b/libraries/chain/include/eosio/chain/eosio_contract.hpp
@@ -30,6 +30,7 @@ namespace eosio {
 
         static const name REQOBTACCOUNT =     name("fio.reqobt");
         static const name FeeContract =       name("fio.fee");
+        static const name StakingContract =   name("fio.staking");
         static const name AddressContract =   name("fio.address");
         static const name TPIDContract =      name("fio.tpid");
         static const name TokenContract =     name("fio.token");

--- a/libraries/chain/include/eosio/chain/eosio_contract.hpp
+++ b/libraries/chain/include/eosio/chain/eosio_contract.hpp
@@ -30,7 +30,6 @@ namespace eosio {
 
         static const name REQOBTACCOUNT =     name("fio.reqobt");
         static const name FeeContract =       name("fio.fee");
-        static const name StakingContract =   name("fio.staking");
         static const name AddressContract =   name("fio.address");
         static const name TPIDContract =      name("fio.tpid");
         static const name TokenContract =     name("fio.token");

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1617,6 +1617,8 @@ if( options.count(name) ) { \
         const string fio_whitelst_scope = "fio.whitelst";   // FIO whitelst contract scope
         const name fio_code = N(eosio);    // FIO system account
         const string fio_scope = "eosio";   // FIO system scope
+        const name fio_staking_code = N(fio.staking);    // FIO system account
+        const string fio_staking_scope = "fio.staking";   // FIO system scope
 
 
         const name fio_whitelist_table = N(whitelist); // FIO Address Table
@@ -1625,6 +1627,7 @@ if( options.count(name) ) { \
         const name fio_domains_table = N(domains); // FIO Domains Table
         const name fio_accounts_table = N(accountmap); // FIO Chains Table
         const name fio_locks_table = N(locktokens); // FIO locktokens Table
+        const name fio_accountstake_table = N(accountstake); // FIO locktokens Table
 
         const uint16_t FEEMAXLENGTH = 32;
         const uint16_t FIOPUBLICKEYLENGTH = 53;
@@ -2554,6 +2557,27 @@ if( options.count(name) ) { \
             return result;
         } // get_fio_addresses
 
+        fc::variant get_staking_row(const database &db, const abi_def &abi, const abi_serializer &abis,
+                                    const fc::microseconds &abi_serializer_max_time_ms, bool shorten_abi_errors) {
+            const auto table_type = get_table_type(abi, N(staking));
+            EOS_ASSERT(table_type == read_only::KEYi64, chain::contract_table_query_exception,
+                       "Invalid table type ${type} for table global", ("type", table_type));
+
+            const auto *const table_id = db.find<chain::table_id_object, chain::by_code_scope_table>(
+                    boost::make_tuple(N(fio.staking), N(fio.staking), N(staking)));
+            EOS_ASSERT(table_id, chain::contract_table_query_exception, "Missing table staking");
+
+            const auto &kv_index = db.get_index<key_value_index, by_scope_primary>();
+            const auto it = kv_index.find(boost::make_tuple(table_id->id, N(staking)));
+            EOS_ASSERT(it != kv_index.end(), chain::contract_table_query_exception, "Missing row in table staking");
+
+            vector<char> data;
+            read_only::copy_inline_row(*it, data);
+            return abis.binary_to_variant(abis.get_table_type(N(staking)), data, abi_serializer_max_time_ms,
+                                          shorten_abi_errors);
+        }
+
+
         read_only::get_fio_balance_result read_only::get_fio_balance(const read_only::get_fio_balance_params &p) const {
             string fioKey = p.fio_public_key;
             FIO_400_ASSERT(fioio::isPubKeyValid(fioKey), "fio_public_key", p.fio_public_key.c_str(),
@@ -2637,10 +2661,58 @@ if( options.count(name) ) { \
                 lockamount = rows_result.rows[0]["remaining_lock_amount"].as_uint64();
             }
 
+            //get the account staking info
+
+            const abi_def staking_abi = eosio::chain_apis::get_abi(db, fio_staking_code);
+
+            get_table_rows_params staking_table_row_params = get_table_rows_params{
+                    .json        = true,
+                    .code        = fio_staking_code,
+                    .scope       = fio_staking_scope,
+                    .table       = fio_accountstake_table,
+                    .lower_bound = boost::lexical_cast<string>(account.value),
+                    .upper_bound = boost::lexical_cast<string>(account.value),
+                    .key_type       = "i64",
+                    .index_position = "2"};
+
+            get_table_rows_result staking_rows_result = get_table_rows_by_seckey<index64_index, uint64_t>(
+                    staking_table_row_params, staking_abi, [](uint64_t v) -> uint64_t {
+                        return v;
+                    });
+
+            uint64_t stakeamount = 0;
+            uint64_t srpamount = 0;
+            if (!staking_rows_result.rows.empty()) {
+
+                FIO_404_ASSERT(staking_rows_result.rows.size() == 1, "Unexpected number of results found in accountstake",
+                               fioio::ErrorUnexpectedNumberResults);
+
+                stakeamount = staking_rows_result.rows[0]["total_staked_fio"].as_uint64();
+                srpamount = staking_rows_result.rows[0]["total_srp"].as_uint64();
+            }
+
+
+            //end get account staking info
             if (!cursor.empty()) {
+                const abi_def abi = eosio::chain_apis::get_abi(db, N(fio.staking));
+                const abi_serializer abis{abi, abi_serializer_max_time};
+                const auto &d = db.db();
+                uint64_t combinedtokenpool =  get_staking_row(d, abi, abis, abi_serializer_max_time,
+                        shorten_abi_errors)["combined_token_pool"].as_uint64();
+                uint64_t globalsrpcount =  get_staking_row(d, abi, abis, abi_serializer_max_time,
+                        shorten_abi_errors)["global_srp_count"].as_uint64();
+
+                uint64_t rateofexchange =  1;
+                if (combinedtokenpool >= 1000000000000000) {
+                    rateofexchange = combinedtokenpool / globalsrpcount;
+                }
+
                 uint64_t rVal = (uint64_t) cursor[0].get_amount();
                 result.balance = rVal;
                 result.available = rVal - lockamount;
+                result.staked = stakeamount;
+                result.srps = srpamount;
+                result.roe = rateofexchange;
             }
 
             return result;
@@ -3373,6 +3445,7 @@ if( options.count(name) ) { \
             return abis.binary_to_variant(abis.get_table_type(N(global)), data, abi_serializer_max_time_ms,
                                           shorten_abi_errors);
         }
+
 
         read_only::get_producers_result read_only::get_producers(const read_only::get_producers_params &p) const {
             const abi_def abi = eosio::chain_apis::get_abi(db, config::system_account_name);

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -649,6 +649,9 @@ namespace eosio {
             struct get_fio_balance_result {
                 uint64_t balance;
                 uint64_t available;
+                uint64_t staked = 0;
+                uint64_t srps = 0;
+                uint64_t roe = 0;
             };
 
             get_fio_balance_result get_fio_balance(const get_fio_balance_params &params) const;
@@ -1578,7 +1581,7 @@ FC_REFLECT(eosio::chain_apis::read_only::get_currency_balance_params, (code)(acc
 FC_REFLECT(eosio::chain_apis::read_only::get_currency_stats_params, (code)(symbol));
 FC_REFLECT(eosio::chain_apis::read_only::get_currency_stats_result, (supply)(max_supply)(issuer));
 FC_REFLECT(eosio::chain_apis::read_only::get_fio_balance_params, (fio_public_key));
-FC_REFLECT(eosio::chain_apis::read_only::get_fio_balance_result, (balance)(available));
+FC_REFLECT(eosio::chain_apis::read_only::get_fio_balance_result, (balance)(available)(staked)(srps)(roe));
 FC_REFLECT(eosio::chain_apis::read_only::get_actor_params, (fio_public_key));
 FC_REFLECT(eosio::chain_apis::read_only::get_actor_result, (actor));
 FC_REFLECT(eosio::chain_apis::read_only::get_producers_params, (json)(lower_bound)(limit))


### PR DESCRIPTION
these changes enhance the FIO core to permit the set of system accounts in the protocol to be gotten from the contract name attribute of the actions table, this uses the contract name in the actions table, and permits new contracts to be added into the FIO protocol without any core code modifications..

