### PR TITLE
BAHAMAS --replay testing, set block boundary after release 2.0.0 for new logic

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1037,8 +1037,7 @@ namespace eosio {
                                                                                   active_producers_authority,
                                                                                   conf.genesis.initial_timestamp);
 
-                /* comment out init for release of bahamas, these changes prohibit genesis node syncing of the chain
-                 * in operations so we remove them for the release image.
+
                 //these actions are added to the action mapping here to permit the launch of
                 //test networks for development testing and private test net testing.
                 //we put the actions into the table here and they are initialized for use
@@ -1377,7 +1376,7 @@ namespace eosio {
                     a.contractname = "eosio.msig";
                     a.blocktimestamp = 1;
                 });
-                 end comment out local init.  */
+
             }
 
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1037,7 +1037,7 @@ namespace eosio {
                                                                                   active_producers_authority,
                                                                                   conf.genesis.initial_timestamp);
 
-
+/* comment out
                 //these actions are added to the action mapping here to permit the launch of
                 //test networks for development testing and private test net testing.
                 //we put the actions into the table here and they are initialized for use
@@ -1377,6 +1377,7 @@ namespace eosio {
                     a.blocktimestamp = 1;
                 });
 
+ end comment */
             }
 
 

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -78,10 +78,8 @@ namespace eosio {
 
                 auto &db = context.db;
 
-                //if its after the hardfork time use the table contents, if not then
-                // use the list to enforce the permitted system accounts
-                const int32_t HF2_BLOCK_TIME = 1600876800  + 15720000; //Wed Sep 23 16:00:00 UTC 2020 + 6 months is end of march
-                if ((context.control.head_block_time().sec_since_epoch() > HF2_BLOCK_TIME)){
+               //if its after release 2.0.0 in block time, use the new logic.
+                if ((context.control.head_block_time().sec_since_epoch() > POST_RELEASE_200_BLOCK_TIME)){
                     //read the actions table get distinct contract names
                     //returns end iterator if index not found during playback.
                     const auto &idx = db.get_index<fioaction_index, by_actionname>();
@@ -97,8 +95,7 @@ namespace eosio {
                     }
                     EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), create.actor) != sysaccts.end()
                             ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
-                }else{ //if there are no system accounts in the list, then we are before the actions table in the playback.
-                    // so use the list of accounts for before actions table
+                }else{ //use the old logic, the list of well known fio accounts before 2.0.0
                     EOS_ASSERT(create.actor == SYSTEMACCOUNT ||
                                create.actor == MSIGACCOUNT ||
                                create.actor == WRAPACCOUNT ||
@@ -150,10 +147,8 @@ namespace eosio {
 
                 auto &db = context.db;
 
-                //if its after the hardfork time use the table contents, if not then
-                // use the list to enforce the permitted system accounts
-                const int32_t HF2_BLOCK_TIME = 1600876800  + 15720000; //Wed Sep 23 16:00:00 UTC 2020 + 6 months is end of march
-                if ((context.control.head_block_time().sec_since_epoch() > HF2_BLOCK_TIME)){
+                //if its after release 2.0.0 in block time use the new logic
+                if ((context.control.head_block_time().sec_since_epoch() > POST_RELEASE_200_BLOCK_TIME)){
                     //read the actions table get distinct contract names
                     //returns end iterator if index not found during playback.
                     const auto &idx = db.get_index<fioaction_index, by_actionname>();
@@ -169,8 +164,7 @@ namespace eosio {
                     }
                     EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), rem.actor) != sysaccts.end()
                             ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
-                }else{ //if there are no system accounts in the list, then we are before the actions table in the playback.
-                    // so use the list of accounts for before actions table
+                }else{ //use the old logic the list of well known fio accounts before 2.0.0
                     EOS_ASSERT(rem.actor == SYSTEMACCOUNT ||
                                rem.actor == MSIGACCOUNT ||
                                rem.actor == WRAPACCOUNT ||
@@ -276,10 +270,8 @@ namespace eosio {
             auto act = context.get_action().data_as<setcode>();
             context.require_authorization(act.account);
 
-            //if its after the hardfork time use the table contents, if not then
-            // use the list to enforce the permitted system accounts
-            const int32_t HF2_BLOCK_TIME = 1600876800  + 15720000; //Wed Sep 23 16:00:00 UTC 2020 + 6 months is end of march
-            if ((context.control.head_block_time().sec_since_epoch() > HF2_BLOCK_TIME)){
+            //if its after release 2.0.0 in block time use the new logic.
+            if ((context.control.head_block_time().sec_since_epoch() > POST_RELEASE_200_BLOCK_TIME)){
                 //read the actions table get distinct contract names
                 //returns end iterator if index not found during playback.
                 const auto &idx = db.get_index<fioaction_index, by_actionname>();
@@ -295,8 +287,7 @@ namespace eosio {
                 }
                 EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), act.account) != sysaccts.end()
                         ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
-            }else{ //if there are no system accounts in the list, then we are before the actions table in the playback.
-                // so use the list of accounts for before actions table
+            }else{ //use the old logic the list of well known system accounts before release 2.0.0
                 EOS_ASSERT(act.account == SYSTEMACCOUNT ||
                            act.account == MSIGACCOUNT ||
                            act.account == WRAPACCOUNT ||

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -77,23 +77,24 @@ namespace eosio {
                 context.require_authorization(create.actor);
 
                 auto &db = context.db;
-                //read the actions table get distinct contract names
-                //returns end iterator if index not found during playback.
-                const auto &idx = db.get_index<fioaction_index, by_actionname>();
-                vector<name> sysaccts;
 
-                // iterate through contract names in actions table
-                //if its before the actions table in playback, we wont execute this loop. idx will be end iterator.
-                for ( auto itr = idx.begin(); itr != idx.end(); itr++ ) {
-                    name nm = name(itr->contractname);
-                    if (std::find(sysaccts.begin(), sysaccts.end(), nm) == sysaccts.end()) {
-                        sysaccts.insert(sysaccts.begin(),nm);
-                    }
-                }
-
-                //if there are system accounts in the list, then the actions table exists,
+                //if its after the hardfork time use the table contents, if not then
                 // use the list to enforce the permitted system accounts
-                if (sysaccts.size() > 0){
+                const int32_t HF2_BLOCK_TIME = 1600876800  + 15720000; //Wed Sep 23 16:00:00 UTC 2020 + 6 months is end of march
+                if ((context.control.head_block_time().sec_since_epoch() > HF2_BLOCK_TIME)){
+                    //read the actions table get distinct contract names
+                    //returns end iterator if index not found during playback.
+                    const auto &idx = db.get_index<fioaction_index, by_actionname>();
+                    vector<name> sysaccts;
+
+                    // iterate through contract names in actions table
+                    //if its before the actions table in playback, we wont execute this loop. idx will be end iterator.
+                    for ( auto itr = idx.begin(); itr != idx.end(); itr++ ) {
+                        name nm = name(itr->contractname);
+                        if (std::find(sysaccts.begin(), sysaccts.end(), nm) == sysaccts.end()) {
+                            sysaccts.insert(sysaccts.begin(),nm);
+                        }
+                    }
                     EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), create.actor) != sysaccts.end()
                             ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
                 }else{ //if there are no system accounts in the list, then we are before the actions table in the playback.
@@ -148,23 +149,24 @@ namespace eosio {
                 context.require_authorization(rem.actor);
 
                 auto &db = context.db;
-                //read the actions table get distinct contract names
-                //returns end iterator if index not found during playback.
-                const auto &idx = db.get_index<fioaction_index, by_actionname>();
-                vector<name> sysaccts;
 
-                // iterate through contract names in actions table
-                //if its before the actions table in playback, we wont execute this loop. idx will be end iterator.
-                for ( auto itr = idx.begin(); itr != idx.end(); itr++ ) {
-                    name nm = name(itr->contractname);
-                    if (std::find(sysaccts.begin(), sysaccts.end(), nm) == sysaccts.end()) {
-                        sysaccts.insert(sysaccts.begin(),nm);
-                    }
-                }
-
-                //if there are system accounts in the list, then the actions table exists,
+                //if its after the hardfork time use the table contents, if not then
                 // use the list to enforce the permitted system accounts
-                if (sysaccts.size() > 0){
+                const int32_t HF2_BLOCK_TIME = 1600876800  + 15720000; //Wed Sep 23 16:00:00 UTC 2020 + 6 months is end of march
+                if ((context.control.head_block_time().sec_since_epoch() > HF2_BLOCK_TIME)){
+                    //read the actions table get distinct contract names
+                    //returns end iterator if index not found during playback.
+                    const auto &idx = db.get_index<fioaction_index, by_actionname>();
+                    vector<name> sysaccts;
+
+                    // iterate through contract names in actions table
+                    //if its before the actions table in playback, we wont execute this loop. idx will be end iterator.
+                    for ( auto itr = idx.begin(); itr != idx.end(); itr++ ) {
+                        name nm = name(itr->contractname);
+                        if (std::find(sysaccts.begin(), sysaccts.end(), nm) == sysaccts.end()) {
+                            sysaccts.insert(sysaccts.begin(),nm);
+                        }
+                    }
                     EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), rem.actor) != sysaccts.end()
                             ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
                 }else{ //if there are no system accounts in the list, then we are before the actions table in the playback.
@@ -274,23 +276,23 @@ namespace eosio {
             auto act = context.get_action().data_as<setcode>();
             context.require_authorization(act.account);
 
-            //read the actions table get distinct contract names
-            //returns end iterator if index not found during playback.
-            const auto &idx = db.get_index<fioaction_index, by_actionname>();
-            vector<name> sysaccts;
-
-            // iterate through contract names in actions table
-            //if its before the actions table in playback, we wont execute this loop. idx will be end iterator.
-            for ( auto itr = idx.begin(); itr != idx.end(); itr++ ) {
-                name nm = name(itr->contractname);
-                if (std::find(sysaccts.begin(), sysaccts.end(), nm) == sysaccts.end()) {
-                    sysaccts.insert(sysaccts.begin(),nm);
-                }
-            }
-
-            //if there are system accounts in the list, then the actions table exists,
+            //if its after the hardfork time use the table contents, if not then
             // use the list to enforce the permitted system accounts
-            if (sysaccts.size() > 0){
+            const int32_t HF2_BLOCK_TIME = 1600876800  + 15720000; //Wed Sep 23 16:00:00 UTC 2020 + 6 months is end of march
+            if ((context.control.head_block_time().sec_since_epoch() > HF2_BLOCK_TIME)){
+                //read the actions table get distinct contract names
+                //returns end iterator if index not found during playback.
+                const auto &idx = db.get_index<fioaction_index, by_actionname>();
+                vector<name> sysaccts;
+
+                // iterate through contract names in actions table
+                //if its before the actions table in playback, we wont execute this loop. idx will be end iterator.
+                for ( auto itr = idx.begin(); itr != idx.end(); itr++ ) {
+                    name nm = name(itr->contractname);
+                    if (std::find(sysaccts.begin(), sysaccts.end(), nm) == sysaccts.end()) {
+                        sysaccts.insert(sysaccts.begin(),nm);
+                    }
+                }
                 EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), act.account) != sysaccts.end()
                         ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
             }else{ //if there are no system accounts in the list, then we are before the actions table in the playback.

--- a/libraries/chain/include/eosio/chain/eosio_contract.hpp
+++ b/libraries/chain/include/eosio/chain/eosio_contract.hpp
@@ -38,6 +38,8 @@ namespace eosio {
         static const name FIOSYSTEMACCOUNT=   name("fio.system");
         static const name FIOACCOUNT =   name("fio");
 
+        static const int POST_RELEASE_200_BLOCK_TIME  = 1616596800; //Wed Mar 24 14:40:00 UTC 2021
+
         /**
          * @defgroup native_action_handlers Native Action Handlers
          */


### PR DESCRIPTION
set a block boundary for the use of the actions table to get the system accounts in the Fio Protocol. any block time after the 2.0.0 release is fine to use, we chose this block time arbitrarily late in march.

The new logic using the actions table requires the actions table be populated for playbacks. so we want to use the new logic AFTER the table has been fully populated, we chose a date and time after the 2.0.0 release of FIO.