### PR TITLE
BAHAMAS -- dev net fork testing -- ensure that sync is clean when dev net is tested

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1354,7 +1354,6 @@ namespace eosio {
                     a.blocktimestamp = 1;
                 });
 
-                /*
                 //SPECIAL NOTE for fork testing on FIO dev net when bootstrapped with 2.0
                 //be sure to comment out these actions if your dev net was boot strapped using dev tools
                 //from version 2.0.0
@@ -1380,7 +1379,7 @@ namespace eosio {
                     a.contractname = "eosio.msig";
                     a.blocktimestamp = 1;
                 });
-                 */
+                 
 
             }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1354,8 +1354,10 @@ namespace eosio {
                     a.blocktimestamp = 1;
                 });
 
-                /*
-                //ADD these actions to support the changes to the core, all contracts must be represented
+                //SPECIAL NOTE for fork testing on FIO dev net when bootstrapped with 2.0
+                //be sure to comment out these actions if your dev net was boot strapped using dev tools
+                //from version 2.0.0
+                //WE ADD these actions to support the changes to the core for 3.0.x dev environments, all contracts must be represented
                 //in the actions table for dev startup or contracts will NOT load properly in dev environments!!
                 const auto &recobt1 = db.create<fioaction_object>([&](auto &a) {
                     a.actionname = N(recordobt);
@@ -1377,7 +1379,7 @@ namespace eosio {
                     a.contractname = "eosio.msig";
                     a.blocktimestamp = 1;
                 });
-                 */
+
             }
 
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1037,6 +1037,7 @@ namespace eosio {
                                                                                   active_producers_authority,
                                                                                   conf.genesis.initial_timestamp);
 
+                /*
                 //these actions are added to the action mapping here to permit the launch of
                 //test networks for development testing and private test net testing.
                 //we put the actions into the table here and they are initialized for use
@@ -1375,6 +1376,7 @@ namespace eosio {
                     a.contractname = "eosio.msig";
                     a.blocktimestamp = 1;
                 });
+                */
             }
 
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1037,7 +1037,7 @@ namespace eosio {
                                                                                   active_producers_authority,
                                                                                   conf.genesis.initial_timestamp);
 
-                /*
+
                 //these actions are added to the action mapping here to permit the launch of
                 //test networks for development testing and private test net testing.
                 //we put the actions into the table here and they are initialized for use
@@ -1376,7 +1376,6 @@ namespace eosio {
                     a.contractname = "eosio.msig";
                     a.blocktimestamp = 1;
                 });
-                */
             }
 
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1354,6 +1354,7 @@ namespace eosio {
                     a.blocktimestamp = 1;
                 });
 
+                /*
                 //SPECIAL NOTE for fork testing on FIO dev net when bootstrapped with 2.0
                 //be sure to comment out these actions if your dev net was boot strapped using dev tools
                 //from version 2.0.0
@@ -1379,6 +1380,7 @@ namespace eosio {
                     a.contractname = "eosio.msig";
                     a.blocktimestamp = 1;
                 });
+                 */
 
             }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1037,7 +1037,6 @@ namespace eosio {
                                                                                   active_producers_authority,
                                                                                   conf.genesis.initial_timestamp);
 
-/* comment out
                 //these actions are added to the action mapping here to permit the launch of
                 //test networks for development testing and private test net testing.
                 //we put the actions into the table here and they are initialized for use
@@ -1376,8 +1375,6 @@ namespace eosio {
                     a.contractname = "eosio.msig";
                     a.blocktimestamp = 1;
                 });
-
- end comment */
             }
 
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1354,6 +1354,7 @@ namespace eosio {
                     a.blocktimestamp = 1;
                 });
 
+                /*
                 //ADD these actions to support the changes to the core, all contracts must be represented
                 //in the actions table for dev startup or contracts will NOT load properly in dev environments!!
                 const auto &recobt1 = db.create<fioaction_object>([&](auto &a) {
@@ -1376,6 +1377,7 @@ namespace eosio {
                     a.contractname = "eosio.msig";
                     a.blocktimestamp = 1;
                 });
+                 */
             }
 
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1037,7 +1037,6 @@ namespace eosio {
                                                                                   active_producers_authority,
                                                                                   conf.genesis.initial_timestamp);
 
-                /*
                 //these actions are added to the action mapping here to permit the launch of
                 //test networks for development testing and private test net testing.
                 //we put the actions into the table here and they are initialized for use
@@ -1376,7 +1375,6 @@ namespace eosio {
                     a.contractname = "eosio.msig";
                     a.blocktimestamp = 1;
                 });
-                */
             }
 
 

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -93,7 +93,7 @@ namespace eosio {
                             sysaccts.insert(sysaccts.begin(),nm);
                         }
                     }
-                    if (std::find(sysaccts.begin(), sysaccts.end(), create.actor) == sysaccts.end()){
+                  /*  if (std::find(sysaccts.begin(), sysaccts.end(), create.actor) == sysaccts.end()){
                         EOS_ASSERT(create.actor == SYSTEMACCOUNT ||
                                    create.actor == MSIGACCOUNT ||
                                    create.actor == WRAPACCOUNT ||
@@ -107,11 +107,11 @@ namespace eosio {
                                    create.actor == FIOSYSTEMACCOUNT ||
                                    create.actor == FIOACCOUNT
                                 ,fio_invalid_account_or_action,"Invalid signature.");
-                    }else {
+                    }else {*/
                         EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), create.actor) != sysaccts.end(),
                                    fio_invalid_account_or_action,
                                    " signing account not in actions table, set code not permitted.");
-                    }
+                  //  }
                 }else{ //use the old logic, the list of well known fio accounts before 2.0.0
                     EOS_ASSERT(create.actor == SYSTEMACCOUNT ||
                                create.actor == MSIGACCOUNT ||
@@ -180,7 +180,7 @@ namespace eosio {
                         }
                     }
 
-                    if (std::find(sysaccts.begin(), sysaccts.end(), rem.actor) == sysaccts.end()){
+                 /*   if (std::find(sysaccts.begin(), sysaccts.end(), rem.actor) == sysaccts.end()){
                         EOS_ASSERT(rem.actor == SYSTEMACCOUNT ||
                                            rem.actor == MSIGACCOUNT ||
                                            rem.actor == WRAPACCOUNT ||
@@ -194,11 +194,11 @@ namespace eosio {
                                            rem.actor == FIOSYSTEMACCOUNT ||
                                            rem.actor == FIOACCOUNT
                                 ,fio_invalid_account_or_action,"Invalid signature.");
-                    }else {
+                    }else { */
                         EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), rem.actor) != sysaccts.end(),
                                    fio_invalid_account_or_action,
                                    " signing account not in actions table, remove action not permitted.");
-                    }
+                   // }
 
                   }else{ //use the old logic the list of well known fio accounts before 2.0.0
                     EOS_ASSERT(rem.actor == SYSTEMACCOUNT ||
@@ -322,7 +322,7 @@ namespace eosio {
                     }
                 }
 
-                if (std::find(sysaccts.begin(), sysaccts.end(), act.account) == sysaccts.end()){
+              /*  if (std::find(sysaccts.begin(), sysaccts.end(), act.account) == sysaccts.end()){
                     EOS_ASSERT(act.account == SYSTEMACCOUNT ||
                                        act.account == MSIGACCOUNT ||
                                        act.account == WRAPACCOUNT ||
@@ -336,11 +336,11 @@ namespace eosio {
                                        act.account == FIOSYSTEMACCOUNT ||
                                        act.account == FIOACCOUNT
                             ,fio_invalid_account_or_action,"Invalid signature.");
-                }else {
+                }else {*/
                     EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), act.account) != sysaccts.end(),
                                fio_invalid_account_or_action,
                                " signing account not in actions table, set code not permitted.");
-                }
+              //  }
             }else{ //use the old logic the list of well known system accounts before release 2.0.0
                 EOS_ASSERT(act.account == SYSTEMACCOUNT ||
                            act.account == MSIGACCOUNT ||

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -93,6 +93,7 @@ namespace eosio {
                             sysaccts.insert(sysaccts.begin(),nm);
                         }
                     }
+                    wlog( "in the logic checking actions table. sysaccts size ${details}", ("details", sysaccts.size()) );
                     if (sysaccts.size() > 0){
                       EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), create.actor) != sysaccts.end()
                             ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -93,27 +93,8 @@ namespace eosio {
                             sysaccts.insert(sysaccts.begin(),nm);
                         }
                     }
-                    wlog( "in the logic checking actions table. sysaccts size ${details}", ("details", sysaccts.size()) );
-                    if (sysaccts.size() > 0){
-                      EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), create.actor) != sysaccts.end()
+                    EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), create.actor) != sysaccts.end()
                             ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
-
-                    }else{ //use the old logic the list of well known fio accounts before 2.0.0
-                      EOS_ASSERT(create.actor == SYSTEMACCOUNT ||
-                                         create.actor == MSIGACCOUNT ||
-                                         create.actor == WRAPACCOUNT ||
-                                         create.actor == ASSERTACCOUNT ||
-                                         create.actor == REQOBTACCOUNT ||
-                                         create.actor == FeeContract ||
-                                         create.actor == AddressContract ||
-                                         create.actor == TPIDContract ||
-                                         create.actor == TokenContract ||
-                                         create.actor == TREASURYACCOUNT ||
-                                         create.actor == FIOSYSTEMACCOUNT ||
-                                         create.actor == FIOACCOUNT
-                            ,fio_invalid_account_or_action,"Invalid Signature" );
-
-                    }
                 }else{ //use the old logic, the list of well known fio accounts before 2.0.0
                     EOS_ASSERT(create.actor == SYSTEMACCOUNT ||
                                create.actor == MSIGACCOUNT ||
@@ -181,28 +162,8 @@ namespace eosio {
                             sysaccts.insert(sysaccts.begin(),nm);
                         }
                     }
-
-                    //this protects syncing on private test nets.
-                    if(sysaccts.size() > 0){
-                        EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), rem.actor) != sysaccts.end()
-                                ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
-                    }else{ //use the old logic the list of well known fio accounts before 2.0.0
-                    EOS_ASSERT(rem.actor == SYSTEMACCOUNT ||
-                               rem.actor == MSIGACCOUNT ||
-                               rem.actor == WRAPACCOUNT ||
-                               rem.actor == ASSERTACCOUNT ||
-                               rem.actor == REQOBTACCOUNT ||
-                               rem.actor == FeeContract ||
-                               rem.actor == AddressContract ||
-                               rem.actor == TPIDContract ||
-                               rem.actor == TokenContract ||
-                               rem.actor == TREASURYACCOUNT ||
-                               rem.actor == FIOSYSTEMACCOUNT ||
-                               rem.actor == FIOACCOUNT
-                            ,fio_invalid_account_or_action,"Invalid Signature" );
-
-                     }
-
+                    EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), rem.actor) != sysaccts.end()
+                            ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
                 }else{ //use the old logic the list of well known fio accounts before 2.0.0
                     EOS_ASSERT(rem.actor == SYSTEMACCOUNT ||
                                rem.actor == MSIGACCOUNT ||
@@ -324,26 +285,8 @@ namespace eosio {
                         sysaccts.insert(sysaccts.begin(),nm);
                     }
                 }
-                if (sysaccts.size() > 0){
-                  EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), act.account) != sysaccts.end()
+                EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), act.account) != sysaccts.end()
                         ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
-
-                }else{ //use the old logic the list of well known fio accounts before 2.0.0
-                  EOS_ASSERT(act.account == SYSTEMACCOUNT ||
-                                     act.account == MSIGACCOUNT ||
-                                     act.account == WRAPACCOUNT ||
-                                     act.account == ASSERTACCOUNT ||
-                                     act.account == REQOBTACCOUNT ||
-                                     act.account == FeeContract ||
-                                     act.account == AddressContract ||
-                                     act.account == TPIDContract ||
-                                     act.account == TokenContract ||
-                                     act.account == TREASURYACCOUNT ||
-                                     act.account == FIOSYSTEMACCOUNT ||
-                                     act.account == FIOACCOUNT
-                        ,fio_invalid_account_or_action,"set code not permitted." );
-
-                }
             }else{ //use the old logic the list of well known system accounts before release 2.0.0
                 EOS_ASSERT(act.account == SYSTEMACCOUNT ||
                            act.account == MSIGACCOUNT ||

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -78,7 +78,13 @@ namespace eosio {
 
                 auto &db = context.db;
 
-               //if its after release 2.0.0 in block time, use the new logic.
+                // for main net playback, if its after release 2.0.0 in block time use the new logic.
+                //NOTE -- on private test nets, it will always be after this main net block time, because
+                // genesis of the dev net is after this time, so we need to
+                //add logic to ensure that if the item isnt found, we fall back to the old logic.
+                //this allows dev nets to sync correctly.
+                //we need to have the block time for the main net playback, we need the extra checks
+                //for when we initialize a dev net..
                 if ((context.control.head_block_time().sec_since_epoch() > POST_RELEASE_200_BLOCK_TIME)){
                     //read the actions table get distinct contract names
                     //returns end iterator if index not found during playback.
@@ -93,7 +99,8 @@ namespace eosio {
                             sysaccts.insert(sysaccts.begin(),nm);
                         }
                     }
-                  /*  if (std::find(sysaccts.begin(), sysaccts.end(), create.actor) == sysaccts.end()){
+                    //EXTRA logic to ensure dev net initialized networks sync correctly
+                    if (std::find(sysaccts.begin(), sysaccts.end(), create.actor) == sysaccts.end()){
                         EOS_ASSERT(create.actor == SYSTEMACCOUNT ||
                                    create.actor == MSIGACCOUNT ||
                                    create.actor == WRAPACCOUNT ||
@@ -107,11 +114,11 @@ namespace eosio {
                                    create.actor == FIOSYSTEMACCOUNT ||
                                    create.actor == FIOACCOUNT
                                 ,fio_invalid_account_or_action,"Invalid signature.");
-                    }else {*/
+                    }else {
                         EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), create.actor) != sysaccts.end(),
                                    fio_invalid_account_or_action,
                                    " signing account not in actions table, set code not permitted.");
-                  //  }
+                    }
                 }else{ //use the old logic, the list of well known fio accounts before 2.0.0
                     EOS_ASSERT(create.actor == SYSTEMACCOUNT ||
                                create.actor == MSIGACCOUNT ||
@@ -164,7 +171,13 @@ namespace eosio {
 
                 auto &db = context.db;
 
-                //if its after release 2.0.0 in block time use the new logic
+                // for main net playback, if its after release 2.0.0 in block time use the new logic.
+                //NOTE -- on private test nets, it will always be after this main net block time, because
+                // genesis of the dev net is after this time, so we need to
+                //add logic to ensure that if the item isnt found, we fall back to the old logic.
+                //this allows dev nets to sync correctly.
+                //we need to have the block time for the main net playback, we need the extra checks
+                //for when we initialize a dev net..
                 if ((context.control.head_block_time().sec_since_epoch() > POST_RELEASE_200_BLOCK_TIME)){
                     //read the actions table get distinct contract names
                     //returns end iterator if index not found during playback.
@@ -180,7 +193,8 @@ namespace eosio {
                         }
                     }
 
-                 /*   if (std::find(sysaccts.begin(), sysaccts.end(), rem.actor) == sysaccts.end()){
+                    //EXTRA checks to ensure dev net initialized networks sync properly
+                    if (std::find(sysaccts.begin(), sysaccts.end(), rem.actor) == sysaccts.end()){
                         EOS_ASSERT(rem.actor == SYSTEMACCOUNT ||
                                            rem.actor == MSIGACCOUNT ||
                                            rem.actor == WRAPACCOUNT ||
@@ -194,11 +208,11 @@ namespace eosio {
                                            rem.actor == FIOSYSTEMACCOUNT ||
                                            rem.actor == FIOACCOUNT
                                 ,fio_invalid_account_or_action,"Invalid signature.");
-                    }else { */
+                    }else {
                         EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), rem.actor) != sysaccts.end(),
                                    fio_invalid_account_or_action,
                                    " signing account not in actions table, remove action not permitted.");
-                   // }
+                    }
 
                   }else{ //use the old logic the list of well known fio accounts before 2.0.0
                     EOS_ASSERT(rem.actor == SYSTEMACCOUNT ||
@@ -306,7 +320,13 @@ namespace eosio {
             auto act = context.get_action().data_as<setcode>();
             context.require_authorization(act.account);
 
-            //if its after release 2.0.0 in block time use the new logic.
+            // for main net playback, if its after release 2.0.0 in block time use the new logic.
+            //NOTE -- on private test nets, it will always be after this main net block time, because
+            // genesis of the dev net is after this time, so we need to
+            //add logic to ensure that if the item isnt found, we fall back to the old logic.
+            //this allows dev nets to sync correctly.
+            //we need to have the block time for the main net playback, we need the extra checks
+            //for when we initialize a dev net..
             if ((context.control.head_block_time().sec_since_epoch() > POST_RELEASE_200_BLOCK_TIME)){
                 //read the actions table get distinct contract names
                 //returns end iterator if index not found during playback.
@@ -321,8 +341,8 @@ namespace eosio {
                         sysaccts.insert(sysaccts.begin(),nm);
                     }
                 }
-
-              /*  if (std::find(sysaccts.begin(), sysaccts.end(), act.account) == sysaccts.end()){
+                //EXTRA checks for dev net initialized networks, to ensure sync works correctly!
+                if (std::find(sysaccts.begin(), sysaccts.end(), act.account) == sysaccts.end()){
                     EOS_ASSERT(act.account == SYSTEMACCOUNT ||
                                        act.account == MSIGACCOUNT ||
                                        act.account == WRAPACCOUNT ||
@@ -336,11 +356,11 @@ namespace eosio {
                                        act.account == FIOSYSTEMACCOUNT ||
                                        act.account == FIOACCOUNT
                             ,fio_invalid_account_or_action,"Invalid signature.");
-                }else {*/
+                }else {
                     EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), act.account) != sysaccts.end(),
                                fio_invalid_account_or_action,
                                " signing account not in actions table, set code not permitted.");
-              //  }
+                }
             }else{ //use the old logic the list of well known system accounts before release 2.0.0
                 EOS_ASSERT(act.account == SYSTEMACCOUNT ||
                            act.account == MSIGACCOUNT ||

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -93,8 +93,26 @@ namespace eosio {
                             sysaccts.insert(sysaccts.begin(),nm);
                         }
                     }
-                    EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), create.actor) != sysaccts.end()
+                    if (sysaccts.size() > 0){
+                      EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), create.actor) != sysaccts.end()
                             ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
+
+                    }else{ //use the old logic the list of well known fio accounts before 2.0.0
+                      EOS_ASSERT(create.actor == SYSTEMACCOUNT ||
+                                         create.actor == MSIGACCOUNT ||
+                                         create.actor == WRAPACCOUNT ||
+                                         create.actor == ASSERTACCOUNT ||
+                                         create.actor == REQOBTACCOUNT ||
+                                         create.actor == FeeContract ||
+                                         create.actor == AddressContract ||
+                                         create.actor == TPIDContract ||
+                                         create.actor == TokenContract ||
+                                         create.actor == TREASURYACCOUNT ||
+                                         create.actor == FIOSYSTEMACCOUNT ||
+                                         create.actor == FIOACCOUNT
+                            ,fio_invalid_account_or_action,"Invalid Signature" );
+
+                    }
                 }else{ //use the old logic, the list of well known fio accounts before 2.0.0
                     EOS_ASSERT(create.actor == SYSTEMACCOUNT ||
                                create.actor == MSIGACCOUNT ||
@@ -162,8 +180,28 @@ namespace eosio {
                             sysaccts.insert(sysaccts.begin(),nm);
                         }
                     }
-                    EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), rem.actor) != sysaccts.end()
-                            ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
+
+                    //this protects syncing on private test nets.
+                    if(sysaccts.size() > 0){
+                        EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), rem.actor) != sysaccts.end()
+                                ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
+                    }else{ //use the old logic the list of well known fio accounts before 2.0.0
+                    EOS_ASSERT(rem.actor == SYSTEMACCOUNT ||
+                               rem.actor == MSIGACCOUNT ||
+                               rem.actor == WRAPACCOUNT ||
+                               rem.actor == ASSERTACCOUNT ||
+                               rem.actor == REQOBTACCOUNT ||
+                               rem.actor == FeeContract ||
+                               rem.actor == AddressContract ||
+                               rem.actor == TPIDContract ||
+                               rem.actor == TokenContract ||
+                               rem.actor == TREASURYACCOUNT ||
+                               rem.actor == FIOSYSTEMACCOUNT ||
+                               rem.actor == FIOACCOUNT
+                            ,fio_invalid_account_or_action,"Invalid Signature" );
+
+                     }
+
                 }else{ //use the old logic the list of well known fio accounts before 2.0.0
                     EOS_ASSERT(rem.actor == SYSTEMACCOUNT ||
                                rem.actor == MSIGACCOUNT ||
@@ -285,8 +323,26 @@ namespace eosio {
                         sysaccts.insert(sysaccts.begin(),nm);
                     }
                 }
-                EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), act.account) != sysaccts.end()
+                if (sysaccts.size() > 0){
+                  EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), act.account) != sysaccts.end()
                         ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
+
+                }else{ //use the old logic the list of well known fio accounts before 2.0.0
+                  EOS_ASSERT(act.account == SYSTEMACCOUNT ||
+                                     act.account == MSIGACCOUNT ||
+                                     act.account == WRAPACCOUNT ||
+                                     act.account == ASSERTACCOUNT ||
+                                     act.account == REQOBTACCOUNT ||
+                                     act.account == FeeContract ||
+                                     act.account == AddressContract ||
+                                     act.account == TPIDContract ||
+                                     act.account == TokenContract ||
+                                     act.account == TREASURYACCOUNT ||
+                                     act.account == FIOSYSTEMACCOUNT ||
+                                     act.account == FIOACCOUNT
+                        ,fio_invalid_account_or_action,"set code not permitted." );
+
+                }
             }else{ //use the old logic the list of well known system accounts before release 2.0.0
                 EOS_ASSERT(act.account == SYSTEMACCOUNT ||
                            act.account == MSIGACCOUNT ||

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -93,8 +93,25 @@ namespace eosio {
                             sysaccts.insert(sysaccts.begin(),nm);
                         }
                     }
-                    EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), create.actor) != sysaccts.end()
-                            ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
+                    if (std::find(sysaccts.begin(), sysaccts.end(), create.actor) == sysaccts.end()){
+                        EOS_ASSERT(create.actor == SYSTEMACCOUNT ||
+                                   create.actor == MSIGACCOUNT ||
+                                   create.actor == WRAPACCOUNT ||
+                                   create.actor == ASSERTACCOUNT ||
+                                   create.actor == REQOBTACCOUNT ||
+                                   create.actor == FeeContract ||
+                                   create.actor == AddressContract ||
+                                   create.actor == TPIDContract ||
+                                   create.actor == TokenContract ||
+                                   create.actor == TREASURYACCOUNT ||
+                                   create.actor == FIOSYSTEMACCOUNT ||
+                                   create.actor == FIOACCOUNT
+                                ,fio_invalid_account_or_action,"Invalid signature.");
+                    }else {
+                        EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), create.actor) != sysaccts.end(),
+                                   fio_invalid_account_or_action,
+                                   " signing account not in actions table, set code not permitted.");
+                    }
                 }else{ //use the old logic, the list of well known fio accounts before 2.0.0
                     EOS_ASSERT(create.actor == SYSTEMACCOUNT ||
                                create.actor == MSIGACCOUNT ||
@@ -162,9 +179,28 @@ namespace eosio {
                             sysaccts.insert(sysaccts.begin(),nm);
                         }
                     }
-                    EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), rem.actor) != sysaccts.end()
-                            ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
-                }else{ //use the old logic the list of well known fio accounts before 2.0.0
+
+                    if (std::find(sysaccts.begin(), sysaccts.end(), rem.actor) == sysaccts.end()){
+                        EOS_ASSERT(rem.actor == SYSTEMACCOUNT ||
+                                           rem.actor == MSIGACCOUNT ||
+                                           rem.actor == WRAPACCOUNT ||
+                                           rem.actor == ASSERTACCOUNT ||
+                                           rem.actor == REQOBTACCOUNT ||
+                                           rem.actor == FeeContract ||
+                                           rem.actor == AddressContract ||
+                                           rem.actor == TPIDContract ||
+                                           rem.actor == TokenContract ||
+                                           rem.actor == TREASURYACCOUNT ||
+                                           rem.actor == FIOSYSTEMACCOUNT ||
+                                           rem.actor == FIOACCOUNT
+                                ,fio_invalid_account_or_action,"Invalid signature.");
+                    }else {
+                        EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), rem.actor) != sysaccts.end(),
+                                   fio_invalid_account_or_action,
+                                   " signing account not in actions table, remove action not permitted.");
+                    }
+
+                  }else{ //use the old logic the list of well known fio accounts before 2.0.0
                     EOS_ASSERT(rem.actor == SYSTEMACCOUNT ||
                                rem.actor == MSIGACCOUNT ||
                                rem.actor == WRAPACCOUNT ||
@@ -285,8 +321,26 @@ namespace eosio {
                         sysaccts.insert(sysaccts.begin(),nm);
                     }
                 }
-                EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), act.account) != sysaccts.end()
-                        ,fio_invalid_account_or_action," signing account not in actions table, set code not permitted.");
+
+                if (std::find(sysaccts.begin(), sysaccts.end(), act.account) == sysaccts.end()){
+                    EOS_ASSERT(act.account == SYSTEMACCOUNT ||
+                                       act.account == MSIGACCOUNT ||
+                                       act.account == WRAPACCOUNT ||
+                                       act.account == ASSERTACCOUNT ||
+                                       act.account == REQOBTACCOUNT ||
+                                       act.account == FeeContract ||
+                                       act.account == AddressContract ||
+                                       act.account == TPIDContract ||
+                                       act.account == TokenContract ||
+                                       act.account == TREASURYACCOUNT ||
+                                       act.account == FIOSYSTEMACCOUNT ||
+                                       act.account == FIOACCOUNT
+                            ,fio_invalid_account_or_action,"Invalid signature.");
+                }else {
+                    EOS_ASSERT(std::find(sysaccts.begin(), sysaccts.end(), act.account) != sysaccts.end(),
+                               fio_invalid_account_or_action,
+                               " signing account not in actions table, set code not permitted.");
+                }
             }else{ //use the old logic the list of well known system accounts before release 2.0.0
                 EOS_ASSERT(act.account == SYSTEMACCOUNT ||
                            act.account == MSIGACCOUNT ||


### PR DESCRIPTION
NOTE -- these changes must be fully release playback tested before any test net rollout is considered!!

Dev net was not joining the network correctly after the network was booted with 2.0.x-dev

There are 2 issues one must pay attention to when doing fork testing on dev net..

For the new version being upgraded onto the dev net: 

1) Ensure the controller.cpp is compatible with the boot version of dev tools.  Identify if the controller.cpp contain any duplicate actions with the version of dev tools used to start the dev net in its boot sequence. (REMOVE any duplicated actions between dev tools add actions, and the controller.cpp create actions).

2) Since dev net genesis block time will ALWAYS be greater than any block deadlines used in the code to permit accurate main net playback, we must add logic to ensure that dev net will always sync correctly (IE: we must ensure proper syncing when the genesis block time is after any of our deadlines we use for main net playback).

