### PR TITLE
fio.escrow API Endpoint

### DIFF
--- a/libraries/chain/include/eosio/chain/fioio/fioerror.hpp
+++ b/libraries/chain/include/eosio/chain/fioio/fioerror.hpp
@@ -94,6 +94,7 @@ namespace fioio {
     constexpr auto ErrorUnexpectedNumberResults = ident | httpLocationError | 156;   // unexpected number of results
     constexpr auto ErrorNoFioActionsFound = ident | httpLocationError | 157;   // no actions found
     constexpr auto ErrorDomainOwner = ident | httpInvalidError | 158;
+    constexpr auto ErrorNoEscrowListingsFound = ident | httpInvalidError | 159;
 
     /**
     * Helper funtions for detecting rich error messages and extracting bitfielded values

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -128,6 +128,7 @@ namespace eosio {
                                      CHAIN_RO_CALL(get_nfts_fio_address, 200),
                                      CHAIN_RO_CALL(get_nfts_hash, 200),
                                      CHAIN_RO_CALL(get_nfts_contract, 200),
+                                     CHAIN_RO_CALL(get_escrow_listings, 200),
                                      CHAIN_RW_CALL_ASYNC(push_block, chain_apis::read_write::push_block_results, 202),
                                      CHAIN_RW_CALL_ASYNC(push_transaction,
                                                          chain_apis::read_write::push_transaction_results, 202),

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1857,19 +1857,28 @@ if( options.count(name) ) { \
                     uint64_t date_listed = requests_rows_result.rows[i + search_offset]["date_listed"].as_uint64();
                     uint64_t date_updated = requests_rows_result.rows[i + search_offset]["date_updated"].as_uint64();
                     string domain = requests_rows_result.rows[i + search_offset]["domain"].as_string();
-                    string domainhash = requests_rows_result.rows[i + search_offset]["domainhash"].as_string();
                     string owner = requests_rows_result.rows[i + search_offset]["owner"].as_string();
-                    string ownerhash = requests_rows_result.rows[i + search_offset]["ownerhash"].as_string();
                     uint64_t sale_price = requests_rows_result.rows[i + search_offset]["sale_price"].as_uint64();
                     uint64_t status = requests_rows_result.rows[i + search_offset]["status"].as_uint64();
 
                     if ((!actorRequired) || (actorRequired && p.actor == owner)) {
-                        time_t temptime;
-                        struct tm *timeinfo;
-                        char buffer[80];
+                        time_t created_temptime;
+                        time_t updated_temptime;
+                        struct tm *created_timeinfo;
+                        struct tm *updated_timeinfo;
+                        char created_buffer[80];
+                        char updated_buffer[80];
 
-                        listing_record rr{id, commission_fee, date_listed, date_updated, domain,
-                                domainhash, owner, ownerhash,sale_price, status};
+                        created_temptime = date_listed;
+                        created_timeinfo = gmtime(&created_temptime);
+                        strftime(created_buffer, 80, "%Y-%m-%dT%T", created_timeinfo);
+
+                        updated_temptime = date_updated;
+                        updated_timeinfo = gmtime(&updated_temptime);
+                        strftime(updated_buffer, 80, "%Y-%m-%dT%T", updated_timeinfo);
+
+                        listing_record rr{id, commission_fee, created_buffer, updated_buffer, domain,
+                                 owner, sale_price, status};
 
                         result.listings.push_back(rr);
                         records_returned++;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1619,7 +1619,9 @@ if( options.count(name) ) { \
         const string fio_scope = "eosio";   // FIO system scope
         const name fio_staking_code = N(fio.staking);    // FIO system account
         const string fio_staking_scope = "fio.staking";   // FIO system scope
-
+        // fio.escrow
+        const name fio_escrow_code = N(fio.escrow); // FIO Escrow account
+        const string fio_escrow_scope = "fio.escrow";
 
         const name fio_whitelist_table = N(whitelist); // FIO Address Table
         const name fio_address_table = N(fionames); // FIO Address Table
@@ -1775,6 +1777,118 @@ if( options.count(name) ) { \
             results.more = count;
             return results;
         } // get_actions
+
+        /***
+      * get escrow listings
+      * @param p status is the value of the status. status = 1: on sale, status = 2: Sold, status = 3; Cancelled
+      * @return listings that are of the status in the request object
+      */
+        read_only::get_escrow_listings_result
+        read_only::get_escrow_listings(const read_only::get_escrow_listings_params &p) const {
+
+            bool actorRequired = false;
+
+            if(p.actor.size()) {
+                actorRequired = true;
+            }
+
+            FIO_400_ASSERT(p.status > 0 && p.status <= 3, "status", to_string(p.status),
+                           "Invalid status value",
+                           fioio::ErrorInvalidValue);
+
+            FIO_400_ASSERT(p.limit >= 0, "limit", to_string(p.limit), "Invalid limit",
+                           fioio::ErrorPagingInvalid);
+
+            FIO_400_ASSERT(p.offset >= 0, "offset", to_string(p.offset), "Invalid offset",
+                           fioio::ErrorPagingInvalid);
+
+            get_escrow_listings_result result;
+            string fio_escrow_lookup_table = "domainsales";   // table name
+            const abi_def escrow_abi = eosio::chain_apis::get_abi(db, fio_escrow_code);
+            uint32_t records_returned = 0;
+            uint32_t records_size = 0;
+            uint32_t search_offset = p.offset;
+
+            get_table_rows_params fio_table_row_params2 = get_table_rows_params{
+                    .json           = true,
+                    .code           = fio_escrow_code,
+                    .scope          = fio_escrow_scope,
+                    .table          = fio_escrow_lookup_table,
+                    .lower_bound    = to_string(p.status),
+                    .upper_bound    = to_string(p.status),
+                    .key_type       = "i64",
+                    .index_position = "4"};
+
+            get_table_rows_result requests_rows_result = get_table_rows_by_seckey<index64_index, uint64_t>(
+                    fio_table_row_params2, escrow_abi,
+                    [](uint64_t v) -> uint64_t {
+                        return v;
+                    });
+
+            if (!requests_rows_result.rows.empty()) {
+                uint32_t search_limit;
+                auto start_time = fc::time_point::now();
+                auto end_time = start_time;
+                records_size = requests_rows_result.rows.size();
+                search_limit = p.limit > 1000 || p.limit == 0 ? 1000 : p.limit;
+                if (search_limit > records_size) { search_limit = records_size; }
+                if (search_offset >= records_size) { records_size = 0; }
+                FIO_404_ASSERT(!(records_size == 0), "No Escrow Listings", fioio::ErrorNoEscrowListingsFound);
+
+                // get proper count for `more` value
+                if(actorRequired) {
+                    records_size = 0;
+                    // iterate through everything
+                    for (auto & row : requests_rows_result.rows) {
+                        // only count record if the owner matches the actor parameter
+                        if(p.actor == row["owner"].as_string()) {
+                            records_size++;
+                        }
+                    }
+                    // if no matches
+                    FIO_404_ASSERT(!(records_size == 0), "No Escrow Listings", fioio::ErrorNoEscrowListingsFound);
+                }
+
+                for (size_t i = 0; i < search_limit; i++) {
+                    if((i + search_offset) == requests_rows_result.rows.size()){ break; }
+                    //get all the attributes of the listing
+                    uint64_t id = requests_rows_result.rows[i + search_offset]["id"].as_uint64();
+                    string commission_fee = requests_rows_result.rows[i + search_offset]["commission_fee"].as_string();
+                    uint64_t date_listed = requests_rows_result.rows[i + search_offset]["date_listed"].as_uint64();
+                    uint64_t date_updated = requests_rows_result.rows[i + search_offset]["date_updated"].as_uint64();
+                    string domain = requests_rows_result.rows[i + search_offset]["domain"].as_string();
+                    string domainhash = requests_rows_result.rows[i + search_offset]["domainhash"].as_string();
+                    string owner = requests_rows_result.rows[i + search_offset]["owner"].as_string();
+                    string ownerhash = requests_rows_result.rows[i + search_offset]["ownerhash"].as_string();
+                    uint64_t sale_price = requests_rows_result.rows[i + search_offset]["sale_price"].as_uint64();
+                    uint64_t status = requests_rows_result.rows[i + search_offset]["status"].as_uint64();
+
+                    if ((!actorRequired) || (actorRequired && p.actor == owner)) {
+                        time_t temptime;
+                        struct tm *timeinfo;
+                        char buffer[80];
+
+                        listing_record rr{id, commission_fee, date_listed, date_updated, domain,
+                                domainhash, owner, ownerhash,sale_price, status};
+
+                        result.listings.push_back(rr);
+                        records_returned++;
+                        end_time = fc::time_point::now();
+                        if (end_time - start_time > fc::microseconds(100000)) {
+                            result.time_limit_exceeded_error = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            FIO_404_ASSERT(!(result.listings.size() == 0), "No Escrow Listings", fioio::ErrorNoEscrowListingsFound);
+            result.more = records_size - records_returned - search_offset;
+            // fix uint overflow
+            if(result.more >= requests_rows_result.rows.size()) {
+                result.more = 0;
+            }
+            return result;
+        } // get_escrow_listings
 
         /***
         * get pending fio requests.

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -78,6 +78,19 @@ namespace eosio {
             string time_stamp;    // FIO blockchain request received timestamp
         };
 
+        struct listing_record {
+            uint64_t id;
+            string commission_fee;
+            uint64_t date_listed;
+            uint64_t date_updated;
+            string domain;
+            string domainhash;
+            string owner;
+            string ownerhash;
+            uint64_t sale_price;
+            uint64_t status;
+        };
+
         struct obt_records {
             string payer_fio_address;   // sender FIO address e.g. john.xyz
             string payee_fio_address;     // receiver FIO address e.g. jane.xyz
@@ -472,6 +485,27 @@ namespace eosio {
 
             get_scheduled_transactions_result
             get_scheduled_transactions(const get_scheduled_transactions_params &params) const;
+
+            ////////////////
+            // FIO ESCROW //
+            //begin get fio escrow listings by status
+            struct get_escrow_listings_params {
+                int32_t status;         // status = 1: on sale, status = 2: Sold, status = 3; Cancelled
+                string actor;
+                int32_t offset = 0;
+                int32_t limit = 1000;
+            };
+
+            struct get_escrow_listings_result {
+                vector <listing_record> listings;
+                uint32_t more;
+                optional<bool> time_limit_exceeded_error;
+            };
+
+            get_escrow_listings_result
+            get_escrow_listings(const get_escrow_listings_params &params) const;
+
+            //end get fio escrow listings by status
 
             ////////////////
             // FIO COMMON //
@@ -1607,6 +1641,8 @@ FC_REFLECT(eosio::chain_apis::read_only::get_nfts_contract_result, (nfts)(more)(
 FC_REFLECT(eosio::chain_apis::nft_info, (fio_address)(chain_code)(contract_address)(token_id)(url)(hash)(metadata))
 FC_REFLECT(eosio::chain_apis::read_only::get_whitelist_params, (fio_public_key))
 FC_REFLECT(eosio::chain_apis::read_only::get_whitelist_result, (whitelisted_parties))
+FC_REFLECT(eosio::chain_apis::read_only::get_escrow_listings_params, (status)(offset)(limit)(actor))
+FC_REFLECT(eosio::chain_apis::read_only::get_escrow_listings_result, (listings)(more)(time_limit_exceeded_error))
 FC_REFLECT(eosio::chain_apis::whitelist_info, (fio_public_key_hash)(content))
 FC_REFLECT(eosio::chain_apis::read_only::check_whitelist_params, (fio_public_key_hash))
 FC_REFLECT(eosio::chain_apis::read_only::check_whitelist_result, (in_whitelist))
@@ -1623,6 +1659,8 @@ FC_REFLECT(eosio::chain_apis::obt_records,
            (payer_fio_address)(payee_fio_address)(payer_fio_public_key)(payee_fio_public_key)(content)(fio_request_id)(
                    time_stamp)
                    (status))
+FC_REFLECT(eosio::chain_apis::listing_record,
+           (id)(commission_fee)(date_listed)(date_updated)(domain)(domainhash)(owner)(ownerhash)(sale_price)(status))
 
 FC_REFLECT(eosio::chain_apis::read_only::get_pub_address_params, (fio_address)(token_code)(chain_code))
 FC_REFLECT(eosio::chain_apis::read_only::get_pub_address_result, (public_address));

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -81,12 +81,10 @@ namespace eosio {
         struct listing_record {
             uint64_t id;
             string commission_fee;
-            uint64_t date_listed;
-            uint64_t date_updated;
+            string date_listed;
+            string date_updated;
             string domain;
-            string domainhash;
             string owner;
-            string ownerhash;
             uint64_t sale_price;
             uint64_t status;
         };
@@ -1660,7 +1658,7 @@ FC_REFLECT(eosio::chain_apis::obt_records,
                    time_stamp)
                    (status))
 FC_REFLECT(eosio::chain_apis::listing_record,
-           (id)(commission_fee)(date_listed)(date_updated)(domain)(domainhash)(owner)(ownerhash)(sale_price)(status))
+           (id)(commission_fee)(date_listed)(date_updated)(domain)(owner)(sale_price)(status))
 
 FC_REFLECT(eosio::chain_apis::read_only::get_pub_address_params, (fio_address)(token_code)(chain_code))
 FC_REFLECT(eosio::chain_apis::read_only::get_pub_address_result, (public_address));


### PR DESCRIPTION
endpoint to get listings by status with an optional parameter of the account name (actor). When filtering by actor, use limit 1000

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [X] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->

this PR adds an endpoint `get_escrow_listings` which takes 3 parameters. `status`, `limit`, and `offset` with an optional parameter `actor`. When the actor parameter is omitted, the limit and offset work fine, and only records of that given status are returned. If the actor parameter is provided it will only get the records with the requested status but also filtered on the given actor. The caveat is that the limit must be set to 1000 because of the additional filtering a lower limit will not work properly. 

If there are 100 records and the 10th record matches the actor parameter but the limit is 1, no records are returned because it is not found within that 1 record. 

## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
