### PR TITLE
BD-3229  FIO STAKING -- correct discrepencies for lockperiodv2

### DIFF
--- a/libraries/chain/include/eosio/chain/contract_types.hpp
+++ b/libraries/chain/include/eosio/chain/contract_types.hpp
@@ -68,17 +68,17 @@ namespace eosio {
             }
         };
 
-        struct lockperiods {
+        struct lockperiodv2 {
             int64_t duration = 0; //duration in seconds. each duration is seconds after grant creation.
-            double percent; //this is the percent to be unlocked
+            int64_t amount; //this is the percent to be unlocked
         };
 
 
         struct trnsloctoks {
             string payee_public_key;
             int32_t can_vote;
-            vector<lockperiods> periods;
-            int32_t amount;
+            vector<lockperiodv2> periods;
+            int64_t amount;
             int64_t max_fee;
             name actor;
             string tpid;
@@ -325,5 +325,5 @@ FC_REFLECT(eosio::chain::regdomain, (fio_domain)(owner_fio_public_key)(max_fee)(
 FC_REFLECT(eosio::chain::burnaddress, (fio_address)(max_fee)(actor)(tpid))
 FC_REFLECT(eosio::chain::xferdomain, (fio_domain)(new_owner_fio_public_key)(max_fee)(actor)(tpid))
 FC_REFLECT(eosio::chain::xferaddress, (fio_address)(new_owner_fio_public_key)(max_fee)(actor)(tpid))
-FC_REFLECT(eosio::chain::lockperiods, (duration)(percent))
+FC_REFLECT(eosio::chain::lockperiodv2, (duration)(amount))
 FC_REFLECT(eosio::chain::trnsloctoks, (payee_public_key)(can_vote)(periods)(amount)(max_fee)(actor)(tpid))


### PR DESCRIPTION
correct type discrepencies inhibiting proper deserialization.


special note --

Testing requirements.

this PR should be tested integrated with a history node to ensure that the trnsloktoks is properly reflected in the history and tx logs.

This PR should be tested with a full playback of the present main net chain.

further testing will be determined by QA, and Eric.