### PR TITLE
Revert get_producers more variable change

### DIFF
--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -454,7 +454,7 @@ namespace eosio {
             struct get_producers_result {
                 vector<fc::variant> producers; ///< one row per item, either encoded as hex string or JSON object
                 double total_producer_vote_weight;
-                uint32_t more; ///< fill lower_bound with this value to fetch more rows
+                string more; ///< fill lower_bound with this value to fetch more rows
             };
 
             get_producers_result get_producers(const get_producers_params &params) const;


### PR DESCRIPTION
This was changed because of an incorrect bug report. 