### PR TITLE
fix BD-3236 BD-3374

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2960,6 +2960,9 @@ if( options.count(name) ) { \
             get_fio_balance_result result;
             vector<asset> cursor;
             result.balance = 0;
+            //set available in result to defaults, if nothing present, 0
+            result.available = 0;
+
 
             uint128_t keyhash = fioio::string_to_uint128_t(fioKey.c_str());
             const abi_def system_abi = eosio::chain_apis::get_abi(db, fio_system_code);
@@ -3675,12 +3678,7 @@ if( options.count(name) ) { \
                 return result;
             }
 
-            uint32_t domain_expiration = (uint32_t) (domain_result.rows[0]["expiration"].as_uint64());
-            uint32_t present_time = (uint32_t) time(0);
-
-            if (present_time > domain_expiration) {
-                return result;
-            }
+            //if its there then it is_registered, regardless of expiration
 
             // name checked and set
             result.is_registered = true;


### PR DESCRIPTION
fix bug in avail_check to return is registered when a domain is present and expired, fix bug in get fio balance when no currency found for this account, return available 0


NOTE -- this needs a complete regression test before it should be considered for hot fix.
NOTE -- this needs a complete regression test before it should be considered for hot fix.
NOTE -- this needs a complete regression test before it should be considered for hot fix.