### PR TITLE
*Test me* Rollback default_max_transaction_cpu_usage

### DIFF
--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -85,7 +85,7 @@ namespace eosio {
 
             const static uint32_t default_max_block_cpu_usage = 200'000; /// max block cpu usage in microseconds
             const static uint32_t default_target_block_cpu_usage_pct = 10 * percent_1;
-            const static uint32_t default_max_transaction_cpu_usage = default_max_block_cpu_usage / 4; /// max trx cpu usage in microseconds
+            const static uint32_t default_max_transaction_cpu_usage = 3 * default_max_block_cpu_usage / 4; /// max trx cpu usage in microseconds
                     //original value of default_max_transaction_cpu_usage //  3 * default_max_block_cpu_usage / 4;
             const static uint32_t default_min_transaction_cpu_usage = 100; /// min trx cpu usage in microseconds (10000 TPS equiv)
             const static uint32_t default_subjective_cpu_leeway_us = 31000; /// default subjective cpu leeway in microseconds


### PR DESCRIPTION
## Consensus Changes
- [ x] Consensus Changes

***** FORKING CHANGE *****
Value has a significant impact on system performance barring slightly slower producers from validating normal transaction loads. Original EOS implementation uses 3 * default_max_transaction_cpu_usage / 4 (150'000), this is a significant increase from the modified value of default_max_transaction_cpu_usage / 4 (50'000). Positive results testing in Ubuntu 18.04 VM (Oracle VBox), requires scale testing.
