### PR TITLE
add xferescrow to history action filtering

### DIFF
--- a/libraries/chain/include/eosio/chain/contract_types.hpp
+++ b/libraries/chain/include/eosio/chain/contract_types.hpp
@@ -155,6 +155,21 @@ namespace eosio {
             }
         };
 
+        struct xferescrow {
+          string fio_domain;
+          string public_key;
+          bool isEscrow;
+          name actor;
+
+            static account_name get_account() {
+                return N(fio.address);
+            }
+
+            static action_name get_name() {
+                return N(xferescrow);
+            }
+        };
+
         struct xferaddress {
           string fio_address;
           string new_owner_fio_public_key;
@@ -324,6 +339,7 @@ FC_REFLECT(eosio::chain::regaddress, (fio_address)(owner_fio_public_key)(max_fee
 FC_REFLECT(eosio::chain::regdomain, (fio_domain)(owner_fio_public_key)(max_fee)(actor)(tpid))
 FC_REFLECT(eosio::chain::burnaddress, (fio_address)(max_fee)(actor)(tpid))
 FC_REFLECT(eosio::chain::xferdomain, (fio_domain)(new_owner_fio_public_key)(max_fee)(actor)(tpid))
+FC_REFLECT(eosio::chain::xferescrow, (fio_domain)(public_key)(isEscrow)(actor))
 FC_REFLECT(eosio::chain::xferaddress, (fio_address)(new_owner_fio_public_key)(max_fee)(actor)(tpid))
 FC_REFLECT(eosio::chain::lockperiodv2, (duration)(amount))
 FC_REFLECT(eosio::chain::trnsloctoks, (payee_public_key)(can_vote)(periods)(amount)(max_fee)(actor)(tpid))

--- a/plugins/history_plugin/history_plugin.cpp
+++ b/plugins/history_plugin/history_plugin.cpp
@@ -249,6 +249,15 @@ namespace eosio {
                       }
                     }
 
+                    if (act.act.name == N(xferescrow)) {
+                      const auto xferdata = act.act.data_as<eosio::xferescrow>();
+                      if(filter_out.find({act.receiver, act.act.name, xferdata.actor}) == filter_out.end() &&
+                         filter_out.find({act.receiver, 0, xferdata.actor}) == filter_out.end() &&
+                         filter_out.find({xferdata.actor, 0, 0}) == filter_out.end()) {
+                        result.insert(fioio::key_to_account(xferdata.public_key));
+                      }
+                    }
+
                     if (act.act.name == N(trnsloctoks)) {
                         const auto xferdata = act.act.data_as<eosio::trnsloctoks>();
                         if(filter_out.find({act.receiver, act.act.name, xferdata.actor}) == filter_out.end() &&


### PR DESCRIPTION
Issue: xferescrow does not come up in block explorers for a public_key's derived account 
Fix: Added xferescrow contract type and object to history action filtering
https://fioprotocol.atlassian.net/browse/BD-4250
