### PR TITLE
Removed error on get_fio_balance on acct having more than 1 lock

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -3658,8 +3658,9 @@ if( options.count(name) ) { \
             uint64_t additional_available_fio_locks = 0;
             if (!grows_result.rows.empty()) {
 
-                FIO_404_ASSERT(grows_result.rows.size() == 1, "Unexpected number of results found for main net locks",
-                               fioio::ErrorUnexpectedNumberResults);
+                if (grows_result.rows.size() > 1) {
+                    dlog(" multiple lock table entries for account " + account.to_string());
+                    }
 
                 uint64_t timestamp = grows_result.rows[0]["timestamp"].as_uint64();
                 uint32_t payouts_performed = grows_result.rows[0]["payouts_performed"].as_uint64();


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
A locking issue uncovered an error workflow that resulted in a degraded user experience. The error path was deemed overly impactful and was removed to prioritize the correct user experience.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
