### PR TITLE
BD-4659 integrate response from state history

### DIFF
--- a/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_serialization.hpp
+++ b/plugins/state_history_plugin/include/eosio/state_history_plugin/state_history_serialization.hpp
@@ -537,6 +537,7 @@ namespace fc {
     datastream<ST> &operator<<(datastream<ST> &ds, const history_serial_wrapper<eosio::chain::action_receipt> &obj) {
         fc::raw::pack(ds, fc::unsigned_int(0));
         fc::raw::pack(ds, as_type<uint64_t>(obj.obj.receiver.value));
+        fc::raw::pack(ds, as_type<std::string>(obj.obj.response));
         fc::raw::pack(ds, as_type<eosio::chain::digest_type>(obj.obj.act_digest));
         fc::raw::pack(ds, as_type<uint64_t>(obj.obj.global_sequence));
         fc::raw::pack(ds, as_type<uint64_t>(obj.obj.recv_sequence));

--- a/plugins/state_history_plugin/state_history_plugin_abi.cpp
+++ b/plugins/state_history_plugin/state_history_plugin_abi.cpp
@@ -77,6 +77,7 @@ extern const char *const state_history_plugin_abi = R"({
         {
             "name": "action_receipt_v0", "fields": [
                 { "name": "receiver", "type": "name" },
+                { "name": "response", "type": "string" },
                 { "name": "act_digest", "type": "checksum256" },
                 { "name": "global_sequence", "type": "uint64" },
                 { "name": "recv_sequence", "type": "uint64" },


### PR DESCRIPTION
this adds the response into the fio action_receipt. 
this change is necessary to run fio.chronicle as part of relic.