### PR TITLE
Updated boost download url

### DIFF
--- a/scripts/helpers/fio_helper.sh
+++ b/scripts/helpers/fio_helper.sh
@@ -384,9 +384,9 @@ function build-boost() {
     echo "Building boost..."
     execute bash -c "cd ${TEMP_DIR} \
         && rm -rf boost_${BOOST_VERSION} \
-        && curl -LO https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION_MAJOR}.${BOOST_VERSION_MINOR}.${BOOST_VERSION_PATCH}/source/boost_${BOOST_VERSION}.tar.bz2 \
-        && tar -xjf boost_${BOOST_VERSION}.tar.bz2 \
-        && rm -f boost_${BOOST_VERSION}.tar.bz2 \
+        && wget https://archives.boost.io/release/${BOOST_VERSION//_/\.}/source/boost_${BOOST_VERSION}.tar.gz \
+        && tar -xf boost_${BOOST_VERSION}.tar.gz \
+        && rm -f boost_${BOOST_VERSION}.tar.gz \
         && cd boost_${BOOST_VERSION} \
         && SDKROOT="$SDKROOT" ./bootstrap.sh ${BOOTSTRAP_FLAGS} --prefix=${FIO_APTS_DIR}"
 }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
The boost c++ library download url changed; the download failed and caused the fio build to fail as it is a dependency. The url was updated, and fio now successfully builds.

This is a build change only and does not affect core functionality.