### PR TITLE
DEMONSTRATION ONLY do not merge!! -- implement a prototype hack level relic api plugin added to fio

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(chain_plugin)
 add_subdirectory(chain_api_plugin)
 add_subdirectory(producer_plugin)
 add_subdirectory(producer_api_plugin)
+
 add_subdirectory(history_plugin)
 add_subdirectory(history_api_plugin)
 add_subdirectory(state_history_plugin)
@@ -19,6 +20,9 @@ add_subdirectory(mongo_db_plugin)
 add_subdirectory(login_plugin)
 add_subdirectory(test_control_plugin)
 add_subdirectory(test_control_api_plugin)
+
+add_subdirectory(relic_plugin)
+add_subdirectory(relic_api_plugin)
 
 # Forward variables to top level so packaging picks them up
 set(CPACK_DEBIAN_PACKAGE_DEPENDS ${CPACK_DEBIAN_PACKAGE_DEPENDS} PARENT_SCOPE)

--- a/plugins/relic_api_plugin/CMakeLists.txt
+++ b/plugins/relic_api_plugin/CMakeLists.txt
@@ -1,0 +1,7 @@
+file(GLOB HEADERS "include/eosio/relic_api_plugin/*.hpp")
+add_library(relic_api_plugin
+        relic_api_plugin.cpp
+        ${HEADERS})
+
+target_link_libraries(relic_api_plugin relic_plugin chain_plugin http_plugin appbase)
+target_include_directories(relic_api_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")

--- a/plugins/relic_api_plugin/include/eosio/relic_api_plugin/relic_api_plugin.hpp
+++ b/plugins/relic_api_plugin/include/eosio/relic_api_plugin/relic_api_plugin.hpp
@@ -1,0 +1,38 @@
+/**
+ *  @file
+ *  @copyright defined in fio/LICENSE
+ */
+#pragma once
+
+#include <eosio/relic_plugin/relic_plugin.hpp>
+#include <eosio/http_plugin/http_plugin.hpp>
+
+#include <appbase/application.hpp>
+#include <eosio/chain/controller.hpp>
+
+namespace eosio {
+    using eosio::chain::controller;
+    using std::unique_ptr;
+    using namespace appbase;
+
+    class relic_api_plugin : public plugin<relic_api_plugin> {
+    public:
+        APPBASE_PLUGIN_REQUIRES((relic_plugin) (chain_plugin) (http_plugin))
+
+        relic_api_plugin();
+
+        virtual ~relic_api_plugin();
+
+        virtual void set_program_options(options_description &, options_description &) override;
+
+        void plugin_initialize(const variables_map &);
+
+        void plugin_startup();
+
+        void plugin_shutdown();
+
+    private:
+        unique_ptr<class relic_api_plugin_impl> my;
+    };
+
+}

--- a/plugins/relic_api_plugin/relic_api_plugin.cpp
+++ b/plugins/relic_api_plugin/relic_api_plugin.cpp
@@ -1,0 +1,70 @@
+/**
+ *  @file
+ *  @copyright defined in fio/LICENSE
+ */
+#include <eosio/relic_api_plugin/relic_api_plugin.hpp>
+#include <eosio/chain/exceptions.hpp>
+
+#include <fc/io/json.hpp>
+
+namespace eosio {
+
+    static appbase::abstract_plugin &_relic_api_plugin = app().register_plugin<relic_api_plugin>();
+
+    using namespace eosio;
+
+    class relic_api_plugin_impl {
+    public:
+        relic_api_plugin_impl(controller &db)
+                : db(db) {}
+
+        controller &db;
+    };
+
+
+    relic_api_plugin::relic_api_plugin() {}
+
+    relic_api_plugin::~relic_api_plugin() {}
+
+    void relic_api_plugin::set_program_options(options_description &, options_description &) {}
+
+    void relic_api_plugin::plugin_initialize(const variables_map &) {}
+
+    struct async_result_visitor : public fc::visitor<std::string> {
+        template<typename T>
+        std::string operator()(const T &v) const {
+            return fc::json::to_string(v);
+        }
+    };
+
+#define CALL(api_name, api_handle, api_namespace, call_name, http_response_code) \
+{std::string("/v1/" #api_name "/" #call_name), \
+   [api_handle](string, string body, url_response_callback cb) mutable { \
+          try { \
+             if (body.empty()) body = "{}"; \
+             fc::variant result( api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>()) ); \
+             cb(http_response_code, std::move(result)); \
+          } catch (...) { \
+             http_plugin::handle_exception(#api_name, #call_name, body, cb); \
+          } \
+       }}
+
+#define RELIC_RO_CALL(call_name, http_response_code) CALL(relic, ro_api, relic_apis::read_only, call_name, http_response_code)
+
+    void relic_api_plugin::plugin_startup() {
+         ilog("starting relic_api_plugin");
+        my.reset(new relic_api_plugin_impl(app().get_plugin<chain_plugin>().chain()));
+        auto ro_api = app().get_plugin<relic_plugin>().get_read_only_api();
+        auto &_http_plugin = app().get_plugin<http_plugin>();
+    
+         ilog("starting adding ro apis");
+
+        _http_plugin.add_api({
+                                                        RELIC_RO_CALL(hello_world, 202)
+                                                });
+         ilog("relic api plugin done adding apis");
+    }
+
+    void relic_api_plugin::plugin_shutdown() {}
+
+}

--- a/plugins/relic_plugin/CMakeLists.txt
+++ b/plugins/relic_plugin/CMakeLists.txt
@@ -1,0 +1,8 @@
+file(GLOB HEADERS "include/eosio/relic_plugin/*.hpp")
+
+add_library(relic_plugin
+        relic_plugin.cpp
+        ${HEADERS})
+
+target_link_libraries(relic_plugin producer_plugin chain_plugin http_client_plugin appbase eosio_chain)
+target_include_directories(relic_plugin PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")

--- a/plugins/relic_plugin/include/eosio/relic_plugin/relic_plugin.hpp
+++ b/plugins/relic_plugin/include/eosio/relic_plugin/relic_plugin.hpp
@@ -1,0 +1,81 @@
+/**
+ *  @file
+ *  @copyright defined in fio/LICENSE
+ */
+#pragma once
+
+#include <appbase/application.hpp>
+#include <eosio/chain_plugin/chain_plugin.hpp>
+#include <fc/variant.hpp>
+#include <memory>
+
+namespace fc { class variant; }
+
+namespace eosio {
+    using namespace appbase;
+    using namespace chain_apis;
+    typedef std::shared_ptr<class relic_plugin_impl> relic_ptr;
+
+    namespace relic_apis {
+       
+        class read_only {
+
+        public:
+            read_only(const relic_ptr &relic)
+                    : my(relic) {}
+
+             struct hello_world_params {
+                int32_t blocknumber;
+            };
+
+            struct hello_world_result {
+                string resultval = "hello world!!";
+                   };
+
+            hello_world_result
+            hello_world(const hello_world_params &params) const;
+
+        private:
+            relic_ptr my;
+        };
+
+
+    } // namespace relic_apis
+
+
+    class relic_plugin : public plugin<relic_plugin> {
+    public:
+        APPBASE_PLUGIN_REQUIRES((chain_plugin))
+
+        relic_plugin();
+
+        relic_plugin(const relic_plugin &) = delete;
+
+        relic_plugin(relic_plugin &&) = delete;
+
+        relic_plugin &operator=(const relic_plugin &) = delete;
+
+        relic_plugin &operator=(relic_plugin &&) = delete;
+
+        virtual ~relic_plugin() override = default;
+
+        virtual void set_program_options(options_description &cli, options_description &cfg) override;
+
+        void plugin_initialize(const variables_map &options);
+
+        void plugin_startup();
+
+        void plugin_shutdown();
+
+        relic_apis::read_only get_read_only_api() const { return relic_apis::read_only(my); }
+
+    private:
+        relic_ptr my;
+    };
+
+}
+
+FC_REFLECT(eosio::relic_apis::read_only::hello_world_params,
+           (blocknumber))
+FC_REFLECT(eosio::relic_apis::read_only::hello_world_result,
+           (resultval))

--- a/plugins/relic_plugin/relic_plugin.cpp
+++ b/plugins/relic_plugin/relic_plugin.cpp
@@ -1,0 +1,67 @@
+/**
+ *  @file
+ *  @copyright defined in fio/LICENSE
+ */
+#include <eosio/relic_plugin/relic_plugin.hpp>
+#include <fc/optional.hpp>
+#include <atomic>
+
+namespace fc { class variant; }
+
+namespace eosio {
+
+    static appbase::abstract_plugin &_relic_plugin = app().register_plugin<relic_plugin>();
+
+    class relic_plugin_impl {
+    public:
+        relic_plugin_impl(chain::controller &c) : _chain(c) {}
+
+        void connect();
+
+        void disconnect();
+
+       
+    private:
+        chain::controller &_chain;
+    };
+
+    void relic_plugin_impl::connect() {
+    }
+
+    void relic_plugin_impl::disconnect() {
+    }
+
+    relic_plugin::relic_plugin() {
+        app().register_config_type<eosio::chain::db_read_mode>();
+        app().register_config_type<eosio::chain::validation_mode>();
+        app().register_config_type<chainbase::pinnable_mapped_file::map_mode>();
+    }
+
+    void relic_plugin::set_program_options(options_description &cli, options_description &cfg) {
+    }
+
+    void relic_plugin::plugin_initialize(const variables_map &options) {
+    }
+
+    void relic_plugin::plugin_startup() {
+        ilog("relic_plugin starting up");
+        my.reset(new relic_plugin_impl(app().get_plugin<chain_plugin>().chain()));
+        my->connect();
+    }
+
+    void relic_plugin::plugin_shutdown() {
+        my->disconnect();
+        ilog("relic_plugin shutting down");
+    }
+
+    namespace relic_apis {
+
+        read_only::hello_world_result
+        read_only::hello_world(const read_only::hello_world_params &p) const {
+            read_only::hello_world_result res;
+            return res;
+        }
+
+    } // namespace relic_apis
+
+} // namespace eosio

--- a/programs/nodeos/CMakeLists.txt
+++ b/programs/nodeos/CMakeLists.txt
@@ -54,6 +54,8 @@ target_link_libraries(${NODE_EXECUTABLE_NAME}
         PRIVATE -Wl,${whole_archive_flag} state_history_plugin -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} history_api_plugin -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} chain_api_plugin -Wl,${no_whole_archive_flag}
+         PRIVATE -Wl,${whole_archive_flag} relic_api_plugin -Wl,${no_whole_archive_flag}
+       
         PRIVATE -Wl,${whole_archive_flag} net_plugin -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} net_api_plugin -Wl,${no_whole_archive_flag}
         #        PRIVATE -Wl,${whole_archive_flag} faucet_testnet_plugin      -Wl,${no_whole_archive_flag}
@@ -63,7 +65,7 @@ target_link_libraries(${NODE_EXECUTABLE_NAME}
         PRIVATE -Wl,${whole_archive_flag} test_control_plugin -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${whole_archive_flag} test_control_api_plugin -Wl,${no_whole_archive_flag}
         PRIVATE -Wl,${build_id_flag}
-        PRIVATE chain_plugin http_plugin producer_plugin http_client_plugin
+        PRIVATE chain_plugin relic_plugin http_plugin producer_plugin http_client_plugin
         PRIVATE eosio_chain fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS})
 
 if (BUILD_MONGO_DB_PLUGIN)

--- a/programs/nodeos/main.cpp
+++ b/programs/nodeos/main.cpp
@@ -4,6 +4,9 @@
  */
 #include <appbase/application.hpp>
 
+#include <../../../plugins/relic_api_plugin/include/eosio/relic_api_plugin/relic_api_plugin.hpp>
+
+#include <../../../plugins/relic_plugin/include/eosio/relic_plugin/relic_plugin.hpp>
 #include <eosio/chain_plugin/chain_plugin.hpp>
 #include <eosio/http_plugin/http_plugin.hpp>
 #include <eosio/net_plugin/net_plugin.hpp>
@@ -83,7 +86,7 @@ int main(int argc, char **argv) {
                                           .default_unix_socket_path = "",
                                           .default_http_port = 8888
                                   });
-        if (!app().initialize<chain_plugin, net_plugin, producer_plugin>(argc, argv))
+        if (!app().initialize<chain_plugin, net_plugin, relic_plugin, relic_api_plugin, producer_plugin>(argc, argv))
             return INITIALIZE_FAIL;
         initialize_logging();
         ilog("${name} version ${ver}", ("name", nodeos::config::node_executable_name)("ver", app().version_string()));


### PR DESCRIPTION
this PR demonstrates the code necessary to get a hack/prototype level relic_api_plugin to return results integrated with the FIO protocol chain plugin...

this is not a completed set of changes, only for demonstration purposes, needs more work to make code properly integrated with cmake include files libraries, and also to ensure the new plugin can optionally be started when nodeos is run.

to run this...
build the branch.
then run a local 3 node dev net. be sure to add the --plugin relic_plugin to your nodeos start.
then you can at the command prompt do the following command and see the rsvp.
curl -X POST -H "Content-Type: application/json" -d '{}' http://localhost:8879/v1/relic/hello_world
