### PR TITLE
fip-0052

### DIFF
--- a/libraries/chain/include/eosio/chain/fioio/fio_common_validator.hpp
+++ b/libraries/chain/include/eosio/chain/fioio/fio_common_validator.hpp
@@ -120,11 +120,14 @@ namespace fioio {
     }
 
     inline bool validateTokenNameFormat(const string &token) {
-        if(token == "*"){
+        if (token.length() >= 1 && token.length() <= 128) {
+            if (token.find_first_not_of("!@#$%^&*()_+=-;:,.<>/?ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789") !=
+                std::string::npos) {
+                return false;
+            }
             return true;
         }
-
-        return validateChainNameFormat(token);
+        return false;
     }
 
     inline bool validateTPIDFormat(const string &tpid) {


### PR DESCRIPTION
## Change Description 
[https://github.com/fioprotocol/fips/blob/master/fip-0052.md](https://github.com/fioprotocol/fio/pull/430)

This FIP implements a new standard for using contract addresses as token codes and modifies on-chain validation to extend the maximum length of token code from 10 to 128 characters and to allow these characters: !@#%^&()_+=-;:,.<>/?.

